### PR TITLE
feat(renderer): add OLED Friendly Mode toggle

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -19,3 +19,55 @@
   top: 0px;
   right: 10px;
 }
+
+html.oledFriendly .appSidebar {
+  /* !important overrides Materialize's grey.lighten-3 (#eee). The pre-filter
+     color must be pure #ffffff so the post-filter result is pure #000000 —
+     true OLED off-pixels. #eee would only invert to #111. */
+  background-color: #ffffff !important;
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* Drift the QR code by a few pixels every minute so its high-contrast
+   pattern doesn't sit on the same OLED subpixels indefinitely. */
+@keyframes oledQrWiggle {
+  0% {
+    transform: translate(0, 0);
+  }
+  12.5% {
+    transform: translate(3px, 2px);
+  }
+  25% {
+    transform: translate(-2px, 3px);
+  }
+  37.5% {
+    transform: translate(2px, -3px);
+  }
+  50% {
+    transform: translate(-3px, -2px);
+  }
+  62.5% {
+    transform: translate(3px, -2px);
+  }
+  75% {
+    transform: translate(-2px, -3px);
+  }
+  87.5% {
+    transform: translate(0, 3px);
+  }
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+html.oledFriendly .appSidebar canvas {
+  animation: oledQrWiggle 480s step-end infinite;
+}
+
+/* Materialize's floating labels and select text default to ~#9e9e9e, which
+   inverts to a mid-gray on the now-black sidebar and reads as "disabled".
+   Darken the source so they invert to high-contrast ~#ddd. */
+html.oledFriendly .appSidebar .input-field > label,
+html.oledFriendly .appSidebar .input-field input[type="text"] {
+  color: #222;
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,8 @@ import Queue from "./Queue";
 import KarafriendsAudio from "./webAudio";
 import { AppQueueAddedSubscription } from "./__generated__/AppQueueAddedSubscription.graphql";
 
+const OLED_FRIENDLY_STORAGE_KEY = "oledFriendly";
+
 interface SavedMic {
   name: string;
   channel: number;
@@ -39,6 +41,25 @@ function App(props: {
   const [mics, _setMics] = useState<InputDevice[]>([]);
   const [hostname, setHostname] = useState(HOSTNAME);
   const [sidebarVisible, setSidebarVisible] = useState(true);
+
+  const [oledFriendly, _setOledFriendly] = useState<boolean>(
+    () => localStorage.getItem(OLED_FRIENDLY_STORAGE_KEY) === "true",
+  );
+
+  const setOledFriendly = (value: boolean) => {
+    if (value) {
+      localStorage.setItem(OLED_FRIENDLY_STORAGE_KEY, "true");
+    } else {
+      localStorage.removeItem(OLED_FRIENDLY_STORAGE_KEY);
+    }
+    _setOledFriendly(value);
+  };
+
+  useEffect(() => {
+    const html = document.documentElement;
+    html.classList.toggle("oledFriendly", oledFriendly);
+    return () => html.classList.remove("oledFriendly");
+  }, [oledFriendly]);
 
   const setMics = (newMics: InputDevice[]) => {
     const micsToSave = newMics.map((mic) => ({
@@ -140,6 +161,17 @@ function App(props: {
             <button className="btn" onClick={clearMics}>
               Clear mics
             </button>
+            <div className="switch">
+              <label>
+                OLED Mode
+                <input
+                  type="checkbox"
+                  checked={oledFriendly}
+                  onChange={(e) => setOledFriendly(e.target.checked)}
+                />
+                <span className="lever"></span>
+              </label>
+            </div>
           </div>
           <nav className="center-align">Queue</nav>
           <Queue />


### PR DESCRIPTION
The renderer's settings sidebar occupies a fixed region of the screen with a light-gray background, plus a high-contrast QR code at the top — both burn-in risks on OLED displays. Add a checkbox under the BGM dropdown that:

* Applies `filter: invert(1) hue-rotate(180deg)` to the sidebar so the light background flips dark while hues stay roughly preserved.
* Overrides the sidebar's `background-color` to `#fff` in the source so it ends up as pure black (0,0,0) after the filter — true OLED off-pixels, not the slightly-lit `#111` that a default `#eee` inversion would produce.
* Keeps the QR code inside the filter (no un-invert), so it renders as white-on-black for visual consistency. QR scanners handle either polarity.
* Shifts the QR canvas through 8 small translations on a step-end keyframe animation, snapping to a new position every 60 seconds over an 8-minute cycle, to avoid sub-pixel burn-in.

Player area is unchanged (already mostly black during karaoke). Selection persists in localStorage.

<img width="1844" height="986" alt="image" src="https://github.com/user-attachments/assets/31812412-1b1b-4ddc-bf94-57b7884226ca" />
<img width="1844" height="986" alt="image" src="https://github.com/user-attachments/assets/53952e7e-ea2c-4df6-9db6-d1e7c95826cf" />
