### PR TITLE
Download external resources at runtime with a per-user cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,11 +32,6 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: pip install ephemeral-port-reserve
-      - uses: MasterworksIO/action-local-cache@2.1.0
-        with:
-          path: |
-            extraResources
-          key: ${{ runner.os }}-resources-${{ hashFiles('scripts/getExternalResources.mjs') }}
       - run: yarn install --immutable
       - run: yarn build-dev
         env:
@@ -81,11 +76,6 @@ jobs:
         with:
           node-version: lts/*
       - run: npm install -g yarn
-      - uses: MasterworksIO/action-local-cache@2.1.0
-        with:
-          path: |
-            extraResources
-          key: ${{ runner.os }}-resources-${{ hashFiles('scripts/getExternalResources.mjs') }}
       - run: yarn install --immutable
       - run: yarn build-dev
         env:
@@ -115,7 +105,6 @@ jobs:
         with:
           path: |
             buildResources
-            extraResources
           key: ${{ runner.os }}-resources-${{ hashFiles('scripts/getExternalResources.mjs') }}
       - run: yarn install --immutable
       - run: yarn build-dev
@@ -142,12 +131,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-      - uses: actions/cache@v5
-        with:
-          path: |
-            buildResources
-            extraResources
-          key: ${{ runner.os }}-resources-${{ hashFiles('scripts/getExternalResources.mjs') }}
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - run: yarn install --immutable
       - run: yarn build-dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
           cache: pip
       - run: pip install ephemeral-port-reserve
       - run: yarn install --immutable
+      - run: yarn test:unit
       - run: yarn build-dev
         env:
           CARGO_ARGS: --target aarch64-apple-darwin
@@ -77,6 +78,7 @@ jobs:
           node-version: lts/*
       - run: npm install -g yarn
       - run: yarn install --immutable
+      - run: yarn test:unit
       - run: yarn build-dev
         env:
           CARGO_ARGS: --target x86_64-apple-darwin
@@ -107,6 +109,7 @@ jobs:
             buildResources
           key: ${{ runner.os }}-resources-${{ hashFiles('scripts/getExternalResources.mjs') }}
       - run: yarn install --immutable
+      - run: yarn test:unit
       - run: yarn build-dev
         env:
           CARGO_ARGS: --features asio
@@ -133,6 +136,7 @@ jobs:
           node-version: lts/*
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - run: yarn install --immutable
+      - run: yarn test:unit
       - run: yarn build-dev
         env:
           CARGO_INCREMENTAL: false

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ yarn-error.log*
 # react-relay
 __generated__
 
-# Extra resources that are downloaded on build
-/extraResources/ffmpeg/**/*
-/extraResources/ytdlp/*
+# Archive extractor copied into the app on build (runtime downloads are cached
+# in the user data directory, not here)
+/extraResources/7za
+/extraResources/7za.exe
 /buildResources/asio/*

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "_run-dev": "yarn build-dev && concurrently --success !command-0 --kill-others \"parcel serve --target remocon --target renderer --dist-dir build/dev --port 3000\" \"wait-on http://127.0.0.1:3000/ && node electron.js build/dev/main_/index.js\"",
     "package-prod": "node ./packager.js",
     "get-external-resources": "node scripts/getExternalResources.mjs",
+    "test:unit": "cross-env NODE_OPTIONS= node --experimental-strip-types --test \"src/**/*.test.ts\"",
     "test:native": "cargo clippy --manifest-path native/Cargo.toml && cargo +nightly careful test --manifest-path native/Cargo.toml",
     "test:wdio": "cross-env KARAFRIENDS_DEV_PORT=\"$(ephemeral-port-reserve)\" yarn _test:wdio",
     "_test:wdio": "concurrently --success !command-0 --kill-others \"unbuffer -p parcel serve --target remocon --target renderer --dist-dir build/dev --port $KARAFRIENDS_DEV_PORT\" \"cross-env KARAFRIENDS_REMOCON_PORT=\\\"$(ephemeral-port-reserve)\\\" yarn _test:wdio:renderer && cross-env KARAFRIENDS_REMOCON_PORT=\\\"$(ephemeral-port-reserve)\\\" yarn _test:wdio:remocon\"",

--- a/packager.js
+++ b/packager.js
@@ -1,11 +1,34 @@
 #!/usr/bin/env yarn node
 const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
 
 const sevenBin = require("7zip-bin");
 const packager = require("electron-packager");
 const { glob } = require("glob");
 
+// Copy the archive extractor for the target architecture into extraResources/
+// so it ships with the app and can unpack the runtime downloads. 7zip-bin lays
+// its binaries out as <root>/<platform>/<arch>/7za[.exe]; path7za points at the
+// host binary, so we derive the package root from it and pick the target arch.
+function bundleExtractor() {
+  const arch = process.env.PACKAGER_ARCH || process.arch;
+  const platformDir = { darwin: "mac", win32: "win", linux: "linux" }[
+    process.platform
+  ];
+  const binName = process.platform === "win32" ? "7za.exe" : "7za";
+  const root = path.resolve(path.dirname(sevenBin.path7za), "..", "..");
+  const src = path.join(root, platformDir, arch, binName);
+  const dest = path.join("extraResources", binName);
+  fs.mkdirSync("extraResources", { recursive: true });
+  fs.copyFileSync(src, dest);
+  if (process.platform !== "win32") {
+    fs.chmodSync(dest, 0o755);
+  }
+}
+
 (async () => {
+  bundleExtractor();
   const buildFiles = new Set([
     "",
     "/package.json",
@@ -30,15 +53,6 @@ const { glob } = require("glob");
       },
       osxSign: {
         identity: "Developer ID Application: Connor Worley (WZ6JC3T383)",
-        // yt-dlp needs to load python dylibs we don't have control over
-        optionsForFile: (path) =>
-          path.endsWith("/yt-dlp_macos")
-            ? {
-                entitlements: [
-                  "com.apple.security.cs.disable-library-validation",
-                ],
-              }
-            : {},
       },
     }),
     ...(process.platform === "win32" && {

--- a/scripts/getExternalResources.mjs
+++ b/scripts/getExternalResources.mjs
@@ -1,17 +1,27 @@
 #!/usr/bin/node
-import fetch from "node-fetch";
-import sevenBin from "7zip-bin";
+import { execFile } from "child_process";
 import fs from "fs";
-import mv from "mv";
 import os from "os";
 import path from "path";
 import process from "process";
-import { exec, execFile } from "child_process";
+import { promisify } from "util";
+
+import sevenBin from "7zip-bin";
+import fetch from "node-fetch";
+
+// The large media binaries are downloaded lazily at runtime and cached on the
+// user's machine (see src/common/externalResources.ts), so they are no longer
+// fetched at build time. This script only prepares build-time resources:
+//   * the archive extractor, copied into extraResources/ so it ships with the
+//     app and can unpack the runtime downloads
+//   * the Windows ASIO SDK, a compile-time dependency of the native module
+
+const execFileAsync = promisify(execFile);
 
 const pathTo7zip = sevenBin.path7za;
-// 7zip-bin >= 5.2.0 ships the unix `7za` without the executable bit under Yarn
-// PnP, so spawning it fails with EACCES. Restore the executable bit. (No-op on
-// Windows, and harmless for versions that already set it.)
+// 7zip-bin ships the unix `7za` without the executable bit under Yarn PnP, so
+// spawning it fails with EACCES. Restore the executable bit. (No-op on Windows,
+// and harmless for versions that already set it.)
 if (process.platform !== "win32") {
   try {
     fs.chmodSync(pathTo7zip, 0o755);
@@ -19,9 +29,9 @@ if (process.platform !== "win32") {
     // best-effort; extraction will surface a clearer error if this fails
   }
 }
-const buildResourcesDir = `${process.cwd()}/buildResources`;
+
 const extraResourcesDir = `${process.cwd()}/extraResources`;
-const maxMsToWaitForExtraction = 20000;
+const buildResourcesDir = `${process.cwd()}/buildResources`;
 
 async function fetchWithRetries(url, retries) {
   let lastError;
@@ -46,9 +56,9 @@ async function fetchWithRetries(url, retries) {
   throw lastError;
 }
 
-async function downloadFile(url, path) {
+async function downloadFile(url, dest) {
   const res = await fetchWithRetries(url, 5);
-  const fileStream = fs.createWriteStream(path);
+  const fileStream = fs.createWriteStream(dest);
   await new Promise((resolve, reject) => {
     res.body.pipe(fileStream);
     res.body.on("error", reject);
@@ -56,250 +66,50 @@ async function downloadFile(url, path) {
   });
 }
 
-const winTasks = {
-  doChecks: () => [
-    fs.existsSync(`${extraResourcesDir}/ytdlp/yt-dlp.exe`),
-    fs.existsSync(`${extraResourcesDir}/ffmpeg/win/ffmpeg.exe`),
-    fs.existsSync(`${buildResourcesDir}/asio/asiosdk/common/asio.h`),
-  ],
-  prepareDirs: async (tmpDir) =>
-    Promise.all([
-      fs.mkdir(`${tmpDir}/ffmpeg/win`, { recursive: true }, () => null),
-      fs.mkdir(`${extraResourcesDir}/ytdlp`, { recursive: true }, () => null),
-      fs.mkdir(
-        `${extraResourcesDir}/ffmpeg/win`,
-        { recursive: true },
-        () => null,
-      ),
-      fs.mkdir(`${tmpDir}/asio`, { recursive: true }, () => null),
-      fs.mkdir(`${buildResourcesDir}/asio`, { recursive: true }, () => null),
-    ]),
-  getAssets: async (tmpDir) =>
-    Promise.all([
-      downloadFile(
-        "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
-        `${extraResourcesDir}/ytdlp/yt-dlp.exe`,
-      ),
-      downloadFile(
-        "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
-        `${tmpDir}/ffmpeg/win/ffmpeg.7z`,
-      ),
-      downloadFile(
-        "https://www.steinberg.net/asiosdk",
-        `${tmpDir}/asio/asio.zip`,
-      ),
-    ]),
-  extractAssets: async (tmpDir, hasFinishedExtracting) => {
-    execFile(
-      pathTo7zip,
-      [
-        "e",
-        `${tmpDir}/ffmpeg/win/ffmpeg.7z`,
-        "-y",
-        `-o${tmpDir}/ffmpeg/win/contents`,
-      ],
-      (error, stdout, stderr) => {
-        mv(
-          `${tmpDir}/ffmpeg/win/contents/ffmpeg.exe`,
-          `${extraResourcesDir}/ffmpeg/win/ffmpeg.exe`,
-          (err) => {
-            if (err) {
-              console.error(error);
-              throw err;
-            }
-            hasFinishedExtracting[0] = true;
-          },
-        );
-      },
-    );
-    execFile(
-      pathTo7zip,
-      ["x", `${tmpDir}/asio/asio.zip`, "-y", `-o${buildResourcesDir}/asio`],
-      (error, stdout, stderr) => {
-        if (error) {
-          console.error(error);
-          throw error;
-        }
-        hasFinishedExtracting[1] = true;
-      },
-    );
-  },
-  setPermissions: () => null,
-};
-
-const macosTasks = {
-  doChecks: () => [
-    fs.existsSync(`${extraResourcesDir}/ytdlp/yt-dlp_macos`),
-    fs.existsSync(`${extraResourcesDir}/ffmpeg/macos/ffmpeg`),
-    fs.existsSync(buildResourcesDir),
-  ],
-  prepareDirs: async (tmpDir) =>
-    Promise.all([
-      fs.mkdir(`${tmpDir}/ffmpeg/macos`, { recursive: true }, () => null),
-      fs.mkdir(`${extraResourcesDir}/ytdlp`, { recursive: true }, () => null),
-      fs.mkdir(
-        `${extraResourcesDir}/ffmpeg/macos`,
-        { recursive: true },
-        () => null,
-      ),
-      fs.mkdir(buildResourcesDir, () => null),
-    ]),
-  getAssets: async (tmpDir) =>
-    Promise.all([
-      downloadFile(
-        "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
-        `${extraResourcesDir}/ytdlp/yt-dlp_macos`,
-      ),
-      downloadFile(
-        "https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip",
-        `${tmpDir}/ffmpeg/macos/ffmpeg.zip`,
-      ),
-    ]),
-  extractAssets: async (tmpDir, hasFinishedExtracting) => {
-    execFile(
-      pathTo7zip,
-      [
-        "e",
-        `${tmpDir}/ffmpeg/macos/ffmpeg.zip`,
-        "-y",
-        `-o${tmpDir}/ffmpeg/macos/contents`,
-      ],
-      (error, stdout, stderr) => {
-        mv(
-          `${tmpDir}/ffmpeg/macos/contents/ffmpeg`,
-          `${extraResourcesDir}/ffmpeg/macos/ffmpeg`,
-          (err) => {
-            if (err) {
-              console.error(error);
-              throw err;
-            }
-            hasFinishedExtracting[0] = true;
-          },
-        );
-      },
-    );
-    hasFinishedExtracting[1] = true;
-  },
-  setPermissions: () => {
-    fs.chmodSync(`${extraResourcesDir}/ffmpeg/macos/ffmpeg`, "755");
-    fs.chmodSync(`${extraResourcesDir}/ytdlp/yt-dlp_macos`, "755");
-  },
-};
-
-const linuxTasks = {
-  doChecks: () => [
-    fs.existsSync(`${extraResourcesDir}/ytdlp/yt-dlp`),
-    fs.existsSync(`${extraResourcesDir}/ffmpeg/linux/ffmpeg`),
-    fs.existsSync(buildResourcesDir),
-  ],
-  prepareDirs: async (tmpDir) =>
-    Promise.all([
-      fs.mkdir(`${tmpDir}/ffmpeg/linux`, { recursive: true }, () => null),
-      fs.mkdir(`${extraResourcesDir}/ytdlp`, { recursive: true }, () => null),
-      fs.mkdir(
-        `${extraResourcesDir}/ffmpeg/linux`,
-        { recursive: true },
-        () => null,
-      ),
-      fs.mkdir(buildResourcesDir, () => null),
-    ]),
-  getAssets: async (tmpDir) =>
-    Promise.all([
-      downloadFile(
-        "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp",
-        `${extraResourcesDir}/ytdlp/yt-dlp`,
-      ),
-      downloadFile(
-        // GitHub-hosted static build; johnvansickle.com resets connections
-        // from CI runner IPs. 7za flat-extraction still yields contents/ffmpeg.
-        "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
-        `${tmpDir}/ffmpeg/linux/ffmpeg.tar.xz`,
-      ),
-    ]),
-  extractAssets: async (tmpDir, hasFinishedExtracting) => {
-    execFile(
-      pathTo7zip,
-      [
-        "e",
-        `${tmpDir}/ffmpeg/linux/ffmpeg.tar.xz`,
-        "-y",
-        `-o${tmpDir}/ffmpeg/linux/xz`,
-      ],
-      (error, stdout, stderr) => {
-        execFile(
-          pathTo7zip,
-          [
-            "e",
-            `${tmpDir}/ffmpeg/linux/xz/ffmpeg.tar`,
-            "-y",
-            `-o${tmpDir}/ffmpeg/linux/contents`,
-          ],
-          (error, stdout, stderr) => {
-            mv(
-              `${tmpDir}/ffmpeg/linux/contents/ffmpeg`,
-              `${extraResourcesDir}/ffmpeg/linux/ffmpeg`,
-              (err) => {
-                if (err) {
-                  console.error(error);
-                  throw err;
-                }
-                hasFinishedExtracting[0] = true;
-              },
-            );
-          },
-        );
-      },
-    );
-    hasFinishedExtracting[1] = true;
-  },
-  setPermissions: () => {
-    fs.chmodSync(`${extraResourcesDir}/ffmpeg/linux/ffmpeg`, "755");
-    fs.chmodSync(`${extraResourcesDir}/ytdlp/yt-dlp`, "755");
-  },
-};
-
-async function getExternalResources(tasks) {
-  if (tasks.doChecks().every((check) => check === true)) {
-    return;
-  }
-  const tmpDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "karafriends_getExternalResources"),
+// Copy the archive extractor into extraResources/ so it ships with the app and
+// can unpack the runtime downloads. Uses the host architecture, which is what
+// runs in development and on the per-arch CI machines; the packager copies the
+// target-architecture extractor for production builds.
+function copyExtractor() {
+  fs.mkdirSync(extraResourcesDir, { recursive: true });
+  const dest = path.join(
+    extraResourcesDir,
+    process.platform === "win32" ? "7za.exe" : "7za",
   );
-  await tasks.prepareDirs(tmpDir);
-  await tasks.getAssets(tmpDir);
-
-  let hasFinishedExtracting = [false, false];
-  let msToWaitForExtraction = maxMsToWaitForExtraction;
-  await tasks.extractAssets(tmpDir, hasFinishedExtracting);
-  await new Promise(async () => {
-    while (
-      msToWaitForExtraction > 0 &&
-      !hasFinishedExtracting.every((x) => x)
-    ) {
-      await new Promise((r) => setTimeout(r, 200));
-      msToWaitForExtraction -= 200;
-    }
-    fs.rmdirSync(tmpDir, { recursive: true });
-    if (!hasFinishedExtracting.every((x) => x)) {
-      console.error(
-        `Extracting resources did not complete after ${maxMsToWaitForExtraction} ms and was aborted!`,
-      );
-      process.exit(1);
-    }
-    if (!tasks.doChecks(tmpDir).every((check) => check === true)) {
-      console.error("An external resource wasn't successfuly downloaded!");
-      process.exit(1);
-    }
-    tasks.setPermissions();
-    process.exit(0);
-  });
+  fs.copyFileSync(pathTo7zip, dest);
+  if (process.platform !== "win32") {
+    fs.chmodSync(dest, 0o755);
+  }
 }
 
-const tasks =
-  process.platform === "win32"
-    ? winTasks
-    : process.platform === "darwin"
-      ? macosTasks
-      : linuxTasks;
+// The ASIO SDK is a Windows-only compile-time dependency of the native module.
+async function getAsioSdk() {
+  const asioHeader = `${buildResourcesDir}/asio/asiosdk/common/asio.h`;
+  if (fs.existsSync(asioHeader)) {
+    return;
+  }
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "karafriends_asio"));
+  const archive = path.join(tmpDir, "asio.zip");
+  fs.mkdirSync(`${buildResourcesDir}/asio`, { recursive: true });
+  try {
+    await downloadFile("https://www.steinberg.net/asiosdk", archive);
+    await execFileAsync(pathTo7zip, [
+      "x",
+      archive,
+      "-y",
+      `-o${buildResourcesDir}/asio`,
+    ]);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+  if (!fs.existsSync(asioHeader)) {
+    console.error("The ASIO SDK wasn't successfully downloaded!");
+    process.exit(1);
+  }
+}
 
-await getExternalResources(tasks);
+copyExtractor();
+
+if (process.platform === "win32") {
+  await getAsioSdk();
+}

--- a/src/common/externalResources.ts
+++ b/src/common/externalResources.ts
@@ -6,15 +6,17 @@ import path from "path";
 import process from "process";
 import { promisify } from "util";
 
-import fetch from "node-fetch";
+import fetch, { Response as FetchResponse } from "node-fetch";
 
 const execFileAsync = promisify(execFile);
 
 // External runtime binaries are downloaded lazily on the user's machine and
 // cached here so they are fetched once and reused across launches, instead of
-// being bundled into every build. The archive extractor is the only piece that
-// ships with the app (see extraResources), because we need it to unpack these
-// downloads at runtime.
+// being bundled into every build. They still need to stay current: the upstream
+// tools update frequently (some are pinned to a "latest" release), so on each
+// launch we ask the server whether a newer version exists and refresh only when
+// it does. The archive extractor is the only piece that ships with the app (see
+// extraResources), because we need it to unpack these downloads at runtime.
 const isDev = process.env.NODE_ENV === "development";
 
 const extractorDir = isDev
@@ -27,6 +29,12 @@ const extractorPath = path.join(
 );
 
 const cacheDir = path.join(app.getPath("userData"), "externalResources");
+const versionsFile = path.join(cacheDir, "versions.json");
+
+// When the server exposes no cache validators for an asset, fall back to
+// refreshing the cached copy once it is older than this, so we neither
+// re-download it on every launch nor let it go stale forever.
+const STALE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface ResourcePaths {
   // Path to the ffmpeg executable
@@ -61,19 +69,55 @@ export function getResourcePaths(): ResourcePaths {
   return resourcePaths;
 }
 
-async function fetchWithRetries(url: string, retries: number) {
+// An HTTP cache validator for a downloaded asset. Persisted between launches so
+// we can make a conditional request and skip the download when it is unchanged.
+interface Validator {
+  etag?: string;
+  lastModified?: string;
+}
+
+type Versions = Record<string, Validator>;
+
+// A single downloadable binary. `materialize` streams an already-fetched 200
+// response into `tmpDir`, unpacks it if necessary, and returns the path of the
+// finished binary to move into place.
+interface Asset {
+  id: string;
+  url: string;
+  dest: string;
+  materialize: (tmpDir: string, res: FetchResponse) => Promise<string>;
+}
+
+function readVersions(): Versions {
+  try {
+    return JSON.parse(fs.readFileSync(versionsFile, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function writeVersions(versions: Versions): Promise<void> {
+  await fsp.mkdir(cacheDir, { recursive: true });
+  await fsp.writeFile(versionsFile, JSON.stringify(versions, null, 2));
+}
+
+// Fetch accepting both 200 (changed / first download) and 304 (unchanged), with
+// exponential backoff. Some hosts (e.g. CDNs that rate-limit certain IPs) reset
+// the connection instead of returning an HTTP error, so we retry on thrown
+// network errors too, not just on non-ok responses.
+async function fetchAsset(
+  url: string,
+  headers: Record<string, string>,
+  retries: number,
+): Promise<FetchResponse> {
   let lastError;
   for (let attempt = 0; attempt <= retries; attempt++) {
     if (attempt > 0) {
-      // Exponential backoff between attempts. Some hosts (e.g. CDNs that
-      // rate-limit certain IPs) reset the connection instead of returning an
-      // HTTP error, so we must retry on thrown network errors too, not just on
-      // non-ok responses.
       await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
     }
     try {
-      const res = await fetch(url);
-      if (res.ok) {
+      const res = await fetch(url, { headers });
+      if (res.ok || res.status === 304) {
         return res;
       }
       lastError = new Error(String(res.status));
@@ -84,8 +128,7 @@ async function fetchWithRetries(url: string, retries: number) {
   throw lastError;
 }
 
-async function downloadFile(url: string, dest: string): Promise<void> {
-  const res = await fetchWithRetries(url, 5);
+async function streamToFile(res: FetchResponse, dest: string): Promise<void> {
   const fileStream = fs.createWriteStream(dest);
   await new Promise<void>((resolve, reject) => {
     res.body!.pipe(fileStream);
@@ -94,10 +137,10 @@ async function downloadFile(url: string, dest: string): Promise<void> {
   });
 }
 
-// Copy an extracted binary into its final cached location atomically: write to
-// a sibling temp file (same directory, so the rename stays on one filesystem)
-// and rename into place last. An interrupted download therefore never leaves a
-// file that looks complete.
+// Move a finished binary into its final cached location atomically: write to a
+// sibling temp file (same directory, so the rename stays on one filesystem) and
+// rename into place last. An interrupted refresh therefore never leaves a file
+// that looks complete, and never corrupts the copy already in use.
 async function finalize(src: string, dest: string): Promise<void> {
   await fsp.mkdir(path.dirname(dest), { recursive: true });
   const partial = `${dest}.part`;
@@ -109,108 +152,205 @@ async function extract(archive: string, outDir: string): Promise<void> {
   await execFileAsync(extractorPath, ["e", archive, "-y", `-o${outDir}`]);
 }
 
-async function installWin(tmpDir: string): Promise<void> {
-  const archive = path.join(tmpDir, "ffmpeg.7z");
-  const ffmpegOut = path.join(tmpDir, "ffmpeg-out");
-  await Promise.all([
-    downloadFile(
-      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
-      path.join(tmpDir, "yt-dlp.exe"),
-    ),
-    downloadFile(
-      "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
-      archive,
-    ),
-  ]);
-  await extract(archive, ffmpegOut);
-  await finalize(path.join(tmpDir, "yt-dlp.exe"), winResourcePaths.ytdlp);
-  await finalize(path.join(ffmpegOut, "ffmpeg.exe"), winResourcePaths.ffmpeg);
+function binaryAsset(id: string, url: string, dest: string): Asset {
+  return {
+    id,
+    url,
+    dest,
+    materialize: async (tmpDir, res) => {
+      const bin = path.join(tmpDir, "bin");
+      await streamToFile(res, bin);
+      return bin;
+    },
+  };
 }
 
-async function installMacos(tmpDir: string): Promise<void> {
-  const archive = path.join(tmpDir, "ffmpeg.zip");
-  const ffmpegOut = path.join(tmpDir, "ffmpeg-out");
-  await Promise.all([
-    downloadFile(
-      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
-      path.join(tmpDir, "yt-dlp_macos"),
-    ),
-    downloadFile("https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip", archive),
-  ]);
-  await extract(archive, ffmpegOut);
-  await finalize(path.join(tmpDir, "yt-dlp_macos"), macosResourcePaths.ytdlp);
-  await finalize(path.join(ffmpegOut, "ffmpeg"), macosResourcePaths.ffmpeg);
+function archiveAsset(
+  id: string,
+  url: string,
+  dest: string,
+  archiveName: string,
+  // Unpack the downloaded archive and return the path of the extracted binary.
+  unpack: (tmpDir: string, archive: string) => Promise<string>,
+): Asset {
+  return {
+    id,
+    url,
+    dest,
+    materialize: async (tmpDir, res) => {
+      const archive = path.join(tmpDir, archiveName);
+      await streamToFile(res, archive);
+      return unpack(tmpDir, archive);
+    },
+  };
 }
 
-async function installLinux(tmpDir: string): Promise<void> {
-  const archive = path.join(tmpDir, "ffmpeg.tar.xz");
-  const tarOut = path.join(tmpDir, "ffmpeg-tar");
-  const ffmpegOut = path.join(tmpDir, "ffmpeg-out");
-  await Promise.all([
-    downloadFile(
-      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp",
-      path.join(tmpDir, "yt-dlp"),
-    ),
-    downloadFile(
-      // GitHub-hosted static build; johnvansickle.com resets connections from
-      // some IPs. Flat extraction still yields the ffmpeg binary.
-      "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
-      archive,
-    ),
-  ]);
-  // .tar.xz needs two passes: first to the .tar, then to the contents.
-  await extract(archive, tarOut);
-  await extract(path.join(tarOut, "ffmpeg.tar"), ffmpegOut);
-  await finalize(path.join(tmpDir, "yt-dlp"), linuxResourcePaths.ytdlp);
-  await finalize(path.join(ffmpegOut, "ffmpeg"), linuxResourcePaths.ffmpeg);
+function platformAssets(): Asset[] {
+  switch (process.platform) {
+    case "win32":
+      return [
+        binaryAsset(
+          "ytdlp",
+          "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
+          winResourcePaths.ytdlp,
+        ),
+        archiveAsset(
+          "ffmpeg",
+          "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
+          winResourcePaths.ffmpeg,
+          "ffmpeg.7z",
+          async (tmpDir, archive) => {
+            const out = path.join(tmpDir, "out");
+            await extract(archive, out);
+            return path.join(out, "ffmpeg.exe");
+          },
+        ),
+      ];
+    case "darwin":
+      return [
+        binaryAsset(
+          "ytdlp",
+          "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
+          macosResourcePaths.ytdlp,
+        ),
+        archiveAsset(
+          "ffmpeg",
+          "https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip",
+          macosResourcePaths.ffmpeg,
+          "ffmpeg.zip",
+          async (tmpDir, archive) => {
+            const out = path.join(tmpDir, "out");
+            await extract(archive, out);
+            return path.join(out, "ffmpeg");
+          },
+        ),
+      ];
+    default:
+      return [
+        binaryAsset(
+          "ytdlp",
+          "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp",
+          linuxResourcePaths.ytdlp,
+        ),
+        archiveAsset(
+          "ffmpeg",
+          // GitHub-hosted static build; johnvansickle.com resets connections
+          // from some IPs. Flat extraction still yields the ffmpeg binary.
+          "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
+          linuxResourcePaths.ffmpeg,
+          "ffmpeg.tar.xz",
+          async (tmpDir, archive) => {
+            // .tar.xz needs two passes: first to the .tar, then to the contents.
+            const tarOut = path.join(tmpDir, "tar");
+            const out = path.join(tmpDir, "out");
+            await extract(archive, tarOut);
+            await extract(path.join(tarOut, "ffmpeg.tar"), out);
+            return path.join(out, "ffmpeg");
+          },
+        ),
+      ];
+  }
 }
 
-function isCached(): boolean {
-  return (
-    fs.existsSync(resourcePaths.ffmpeg) && fs.existsSync(resourcePaths.ytdlp)
-  );
+function isStale(dest: string): boolean {
+  try {
+    return Date.now() - fs.statSync(dest).mtimeMs > STALE_MS;
+  } catch {
+    return true;
+  }
 }
 
-async function doEnsure(): Promise<void> {
-  if (isCached()) {
-    return;
+// Make sure a single asset is present and up to date. Returns true when the
+// cached copy changed (so the version metadata needs to be persisted).
+async function ensureAsset(asset: Asset, versions: Versions): Promise<boolean> {
+  const exists = fs.existsSync(asset.dest);
+  const stored = versions[asset.id] ?? {};
+  const canValidate = Boolean(stored.etag || stored.lastModified);
+
+  // Without a stored validator we cannot make a conditional request, so a plain
+  // GET would re-download every launch. Skip until the cached copy is stale.
+  if (exists && !canValidate && !isStale(asset.dest)) {
+    return false;
+  }
+
+  const headers: Record<string, string> = {};
+  if (exists && stored.etag) {
+    headers["If-None-Match"] = stored.etag;
+  }
+  if (exists && stored.lastModified) {
+    headers["If-Modified-Since"] = stored.lastModified;
+  }
+
+  let res: FetchResponse;
+  try {
+    res = await fetchAsset(asset.url, headers, 5);
+  } catch (err) {
+    // Offline or the server is unreachable. Keep whatever we already have; only
+    // fail if there is nothing cached to fall back on.
+    if (exists) {
+      console.error(`Keeping cached ${asset.id}; version check failed: ${err}`);
+      return false;
+    }
+    throw err;
+  }
+
+  if (res.status === 304) {
+    return false;
   }
 
   const tmpDir = fs.mkdtempSync(
     path.join(os.tmpdir(), "karafriends_externalResources"),
   );
-
   try {
-    switch (process.platform) {
-      case "win32":
-        await installWin(tmpDir);
-        break;
-      case "darwin":
-        await installMacos(tmpDir);
-        break;
-      default:
-        await installLinux(tmpDir);
-        break;
-    }
-
+    const src = await asset.materialize(tmpDir, res);
+    await finalize(src, asset.dest);
     if (process.platform !== "win32") {
-      fs.chmodSync(resourcePaths.ffmpeg, 0o755);
-      fs.chmodSync(resourcePaths.ytdlp, 0o755);
+      fs.chmodSync(asset.dest, 0o755);
     }
-
-    if (!isCached()) {
-      throw new Error("An external resource wasn't successfully downloaded!");
+  } catch (err) {
+    // A failed refresh must not destroy a working cached copy.
+    if (exists) {
+      console.error(`Keeping cached ${asset.id}; update failed: ${err}`);
+      return false;
     }
+    throw err;
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  versions[asset.id] = {
+    etag: res.headers.get("etag") ?? undefined,
+    lastModified: res.headers.get("last-modified") ?? undefined,
+  };
+  return true;
+}
+
+async function doEnsure(): Promise<void> {
+  const assets = platformAssets();
+  const versions = readVersions();
+
+  const changed = await Promise.all(
+    assets.map((asset) => ensureAsset(asset, versions)),
+  );
+
+  if (changed.some(Boolean)) {
+    await writeVersions(versions);
+  }
+
+  if (
+    !fs.existsSync(resourcePaths.ffmpeg) ||
+    !fs.existsSync(resourcePaths.ytdlp)
+  ) {
+    throw new Error("An external resource wasn't successfully downloaded!");
   }
 }
 
 let ensurePromise: Promise<void> | null = null;
 
-// Download and cache the external runtime binaries if they are not already
-// present. Idempotent: concurrent and repeat calls share a single in-flight
-// download, and a failed attempt is cleared so a later call can retry.
+// Make sure the external runtime binaries are present and up to date, fetching
+// or refreshing them as needed. Runs its checks once per launch: concurrent and
+// repeat calls within a launch share a single in-flight promise, and a failed
+// attempt is cleared so a later call can retry.
 export function ensureExternalResources(): Promise<void> {
   if (!ensurePromise) {
     ensurePromise = doEnsure().catch((err) => {

--- a/src/common/externalResources.ts
+++ b/src/common/externalResources.ts
@@ -1,0 +1,222 @@
+import { execFile } from "child_process";
+import { app } from "electron"; // tslint:disable-line:no-implicit-dependencies
+import fs, { promises as fsp } from "fs";
+import os from "os";
+import path from "path";
+import process from "process";
+import { promisify } from "util";
+
+import fetch from "node-fetch";
+
+const execFileAsync = promisify(execFile);
+
+// External runtime binaries are downloaded lazily on the user's machine and
+// cached here so they are fetched once and reused across launches, instead of
+// being bundled into every build. The archive extractor is the only piece that
+// ships with the app (see extraResources), because we need it to unpack these
+// downloads at runtime.
+const isDev = process.env.NODE_ENV === "development";
+
+const extractorDir = isDev
+  ? path.join(app.getAppPath(), "..", "..", "..", "extraResources")
+  : path.join(process.resourcesPath, "extraResources");
+
+const extractorPath = path.join(
+  extractorDir,
+  process.platform === "win32" ? "7za.exe" : "7za",
+);
+
+const cacheDir = path.join(app.getPath("userData"), "externalResources");
+
+export interface ResourcePaths {
+  // Path to the ffmpeg executable
+  ffmpeg: string;
+  // Path to the ytdlp executable
+  ytdlp: string;
+}
+
+const linuxResourcePaths: ResourcePaths = {
+  ffmpeg: path.join(cacheDir, "ffmpeg", "ffmpeg"),
+  ytdlp: path.join(cacheDir, "ytdlp", "yt-dlp"),
+};
+
+const macosResourcePaths: ResourcePaths = {
+  ffmpeg: path.join(cacheDir, "ffmpeg", "ffmpeg"),
+  ytdlp: path.join(cacheDir, "ytdlp", "yt-dlp_macos"),
+};
+
+const winResourcePaths: ResourcePaths = {
+  ffmpeg: path.join(cacheDir, "ffmpeg", "ffmpeg.exe"),
+  ytdlp: path.join(cacheDir, "ytdlp", "yt-dlp.exe"),
+};
+
+const resourcePaths: ResourcePaths =
+  process.platform === "win32"
+    ? winResourcePaths
+    : process.platform === "darwin"
+      ? macosResourcePaths
+      : linuxResourcePaths;
+
+export function getResourcePaths(): ResourcePaths {
+  return resourcePaths;
+}
+
+async function fetchWithRetries(url: string, retries: number) {
+  let lastError;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) {
+      // Exponential backoff between attempts. Some hosts (e.g. CDNs that
+      // rate-limit certain IPs) reset the connection instead of returning an
+      // HTTP error, so we must retry on thrown network errors too, not just on
+      // non-ok responses.
+      await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
+    }
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res;
+      }
+      lastError = new Error(String(res.status));
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+  const res = await fetchWithRetries(url, 5);
+  const fileStream = fs.createWriteStream(dest);
+  await new Promise<void>((resolve, reject) => {
+    res.body!.pipe(fileStream);
+    res.body!.on("error", reject);
+    fileStream.on("finish", () => resolve());
+  });
+}
+
+// Copy an extracted binary into its final cached location atomically: write to
+// a sibling temp file (same directory, so the rename stays on one filesystem)
+// and rename into place last. An interrupted download therefore never leaves a
+// file that looks complete.
+async function finalize(src: string, dest: string): Promise<void> {
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  const partial = `${dest}.part`;
+  await fsp.copyFile(src, partial);
+  await fsp.rename(partial, dest);
+}
+
+async function extract(archive: string, outDir: string): Promise<void> {
+  await execFileAsync(extractorPath, ["e", archive, "-y", `-o${outDir}`]);
+}
+
+async function installWin(tmpDir: string): Promise<void> {
+  const archive = path.join(tmpDir, "ffmpeg.7z");
+  const ffmpegOut = path.join(tmpDir, "ffmpeg-out");
+  await Promise.all([
+    downloadFile(
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
+      path.join(tmpDir, "yt-dlp.exe"),
+    ),
+    downloadFile(
+      "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
+      archive,
+    ),
+  ]);
+  await extract(archive, ffmpegOut);
+  await finalize(path.join(tmpDir, "yt-dlp.exe"), winResourcePaths.ytdlp);
+  await finalize(path.join(ffmpegOut, "ffmpeg.exe"), winResourcePaths.ffmpeg);
+}
+
+async function installMacos(tmpDir: string): Promise<void> {
+  const archive = path.join(tmpDir, "ffmpeg.zip");
+  const ffmpegOut = path.join(tmpDir, "ffmpeg-out");
+  await Promise.all([
+    downloadFile(
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
+      path.join(tmpDir, "yt-dlp_macos"),
+    ),
+    downloadFile("https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip", archive),
+  ]);
+  await extract(archive, ffmpegOut);
+  await finalize(path.join(tmpDir, "yt-dlp_macos"), macosResourcePaths.ytdlp);
+  await finalize(path.join(ffmpegOut, "ffmpeg"), macosResourcePaths.ffmpeg);
+}
+
+async function installLinux(tmpDir: string): Promise<void> {
+  const archive = path.join(tmpDir, "ffmpeg.tar.xz");
+  const tarOut = path.join(tmpDir, "ffmpeg-tar");
+  const ffmpegOut = path.join(tmpDir, "ffmpeg-out");
+  await Promise.all([
+    downloadFile(
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp",
+      path.join(tmpDir, "yt-dlp"),
+    ),
+    downloadFile(
+      // GitHub-hosted static build; johnvansickle.com resets connections from
+      // some IPs. Flat extraction still yields the ffmpeg binary.
+      "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
+      archive,
+    ),
+  ]);
+  // .tar.xz needs two passes: first to the .tar, then to the contents.
+  await extract(archive, tarOut);
+  await extract(path.join(tarOut, "ffmpeg.tar"), ffmpegOut);
+  await finalize(path.join(tmpDir, "yt-dlp"), linuxResourcePaths.ytdlp);
+  await finalize(path.join(ffmpegOut, "ffmpeg"), linuxResourcePaths.ffmpeg);
+}
+
+function isCached(): boolean {
+  return (
+    fs.existsSync(resourcePaths.ffmpeg) && fs.existsSync(resourcePaths.ytdlp)
+  );
+}
+
+async function doEnsure(): Promise<void> {
+  if (isCached()) {
+    return;
+  }
+
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "karafriends_externalResources"),
+  );
+
+  try {
+    switch (process.platform) {
+      case "win32":
+        await installWin(tmpDir);
+        break;
+      case "darwin":
+        await installMacos(tmpDir);
+        break;
+      default:
+        await installLinux(tmpDir);
+        break;
+    }
+
+    if (process.platform !== "win32") {
+      fs.chmodSync(resourcePaths.ffmpeg, 0o755);
+      fs.chmodSync(resourcePaths.ytdlp, 0o755);
+    }
+
+    if (!isCached()) {
+      throw new Error("An external resource wasn't successfully downloaded!");
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+let ensurePromise: Promise<void> | null = null;
+
+// Download and cache the external runtime binaries if they are not already
+// present. Idempotent: concurrent and repeat calls share a single in-flight
+// download, and a failed attempt is cleared so a later call can retry.
+export function ensureExternalResources(): Promise<void> {
+  if (!ensurePromise) {
+    ensurePromise = doEnsure().catch((err) => {
+      ensurePromise = null;
+      throw err;
+    });
+  }
+  return ensurePromise;
+}

--- a/src/common/externalResources.ts
+++ b/src/common/externalResources.ts
@@ -8,6 +8,18 @@ import { promisify } from "util";
 
 import fetch, { Response as FetchResponse } from "node-fetch";
 
+import {
+  AssetPlan,
+  assetPlans,
+  canSkipUnvalidated,
+  conditionalHeaders,
+  extractorFileName,
+  isStale,
+  ResourcePaths,
+  resourcePathsFor,
+  Versions,
+} from "./externalResourcesPlan";
+
 const execFileAsync = promisify(execFile);
 
 // External runtime binaries are downloaded lazily on the user's machine and
@@ -17,6 +29,10 @@ const execFileAsync = promisify(execFile);
 // launch we ask the server whether a newer version exists and refresh only when
 // it does. The archive extractor is the only piece that ships with the app (see
 // extraResources), because we need it to unpack these downloads at runtime.
+//
+// The pure planning and decision logic lives in externalResourcesPlan.ts so it
+// can be unit tested across platforms without electron, the filesystem, or the
+// network; this module wires that plan up to the real side effects.
 const isDev = process.env.NODE_ENV === "development";
 
 const extractorDir = isDev
@@ -25,67 +41,19 @@ const extractorDir = isDev
 
 const extractorPath = path.join(
   extractorDir,
-  process.platform === "win32" ? "7za.exe" : "7za",
+  extractorFileName(process.platform),
 );
 
 const cacheDir = path.join(app.getPath("userData"), "externalResources");
 const versionsFile = path.join(cacheDir, "versions.json");
 
-// When the server exposes no cache validators for an asset, fall back to
-// refreshing the cached copy once it is older than this, so we neither
-// re-download it on every launch nor let it go stale forever.
-const STALE_MS = 7 * 24 * 60 * 60 * 1000;
-
-export interface ResourcePaths {
-  // Path to the ffmpeg executable
-  ffmpeg: string;
-  // Path to the ytdlp executable
-  ytdlp: string;
-}
-
-const linuxResourcePaths: ResourcePaths = {
-  ffmpeg: path.join(cacheDir, "ffmpeg", "ffmpeg"),
-  ytdlp: path.join(cacheDir, "ytdlp", "yt-dlp"),
-};
-
-const macosResourcePaths: ResourcePaths = {
-  ffmpeg: path.join(cacheDir, "ffmpeg", "ffmpeg"),
-  ytdlp: path.join(cacheDir, "ytdlp", "yt-dlp_macos"),
-};
-
-const winResourcePaths: ResourcePaths = {
-  ffmpeg: path.join(cacheDir, "ffmpeg", "ffmpeg.exe"),
-  ytdlp: path.join(cacheDir, "ytdlp", "yt-dlp.exe"),
-};
-
-const resourcePaths: ResourcePaths =
-  process.platform === "win32"
-    ? winResourcePaths
-    : process.platform === "darwin"
-      ? macosResourcePaths
-      : linuxResourcePaths;
+const resourcePaths: ResourcePaths = resourcePathsFor(
+  process.platform,
+  cacheDir,
+);
 
 export function getResourcePaths(): ResourcePaths {
   return resourcePaths;
-}
-
-// An HTTP cache validator for a downloaded asset. Persisted between launches so
-// we can make a conditional request and skip the download when it is unchanged.
-interface Validator {
-  etag?: string;
-  lastModified?: string;
-}
-
-type Versions = Record<string, Validator>;
-
-// A single downloadable binary. `materialize` streams an already-fetched 200
-// response into `tmpDir`, unpacks it if necessary, and returns the path of the
-// finished binary to move into place.
-interface Asset {
-  id: string;
-  url: string;
-  dest: string;
-  materialize: (tmpDir: string, res: FetchResponse) => Promise<string>;
 }
 
 function readVersions(): Versions {
@@ -152,143 +120,62 @@ async function extract(archive: string, outDir: string): Promise<void> {
   await execFileAsync(extractorPath, ["e", archive, "-y", `-o${outDir}`]);
 }
 
-function binaryAsset(id: string, url: string, dest: string): Asset {
-  return {
-    id,
-    url,
-    dest,
-    materialize: async (tmpDir, res) => {
-      const bin = path.join(tmpDir, "bin");
-      await streamToFile(res, bin);
-      return bin;
-    },
-  };
-}
-
-function archiveAsset(
-  id: string,
-  url: string,
-  dest: string,
-  archiveName: string,
-  // Unpack the downloaded archive and return the path of the extracted binary.
-  unpack: (tmpDir: string, archive: string) => Promise<string>,
-): Asset {
-  return {
-    id,
-    url,
-    dest,
-    materialize: async (tmpDir, res) => {
-      const archive = path.join(tmpDir, archiveName);
-      await streamToFile(res, archive);
-      return unpack(tmpDir, archive);
-    },
-  };
-}
-
-function platformAssets(): Asset[] {
-  switch (process.platform) {
-    case "win32":
-      return [
-        binaryAsset(
-          "ytdlp",
-          "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
-          winResourcePaths.ytdlp,
-        ),
-        archiveAsset(
-          "ffmpeg",
-          "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
-          winResourcePaths.ffmpeg,
-          "ffmpeg.7z",
-          async (tmpDir, archive) => {
-            const out = path.join(tmpDir, "out");
-            await extract(archive, out);
-            return path.join(out, "ffmpeg.exe");
-          },
-        ),
-      ];
-    case "darwin":
-      return [
-        binaryAsset(
-          "ytdlp",
-          "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
-          macosResourcePaths.ytdlp,
-        ),
-        archiveAsset(
-          "ffmpeg",
-          "https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip",
-          macosResourcePaths.ffmpeg,
-          "ffmpeg.zip",
-          async (tmpDir, archive) => {
-            const out = path.join(tmpDir, "out");
-            await extract(archive, out);
-            return path.join(out, "ffmpeg");
-          },
-        ),
-      ];
-    default:
-      return [
-        binaryAsset(
-          "ytdlp",
-          "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp",
-          linuxResourcePaths.ytdlp,
-        ),
-        archiveAsset(
-          "ffmpeg",
-          // GitHub-hosted static build; johnvansickle.com resets connections
-          // from some IPs. Flat extraction still yields the ffmpeg binary.
-          "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
-          linuxResourcePaths.ffmpeg,
-          "ffmpeg.tar.xz",
-          async (tmpDir, archive) => {
-            // .tar.xz needs two passes: first to the .tar, then to the contents.
-            const tarOut = path.join(tmpDir, "tar");
-            const out = path.join(tmpDir, "out");
-            await extract(archive, tarOut);
-            await extract(path.join(tarOut, "ffmpeg.tar"), out);
-            return path.join(out, "ffmpeg");
-          },
-        ),
-      ];
+// Download an asset into `tmpDir`, unpack it per its plan, and return the path
+// of the finished binary to move into place.
+async function materialize(
+  plan: AssetPlan,
+  tmpDir: string,
+  res: FetchResponse,
+): Promise<string> {
+  if (plan.download.kind === "binary") {
+    const bin = path.join(tmpDir, "bin");
+    await streamToFile(res, bin);
+    return bin;
   }
+
+  const { archiveName, steps, binary } = plan.download;
+  await streamToFile(res, path.join(tmpDir, archiveName));
+  for (const step of steps) {
+    await extract(
+      path.join(tmpDir, step.input),
+      path.join(tmpDir, step.outDir),
+    );
+  }
+  return path.join(tmpDir, binary);
 }
 
-function isStale(dest: string): boolean {
+function mtimeMs(dest: string): number {
   try {
-    return Date.now() - fs.statSync(dest).mtimeMs > STALE_MS;
+    return fs.statSync(dest).mtimeMs;
   } catch {
-    return true;
+    return 0;
   }
 }
 
 // Make sure a single asset is present and up to date. Returns true when the
 // cached copy changed (so the version metadata needs to be persisted).
-async function ensureAsset(asset: Asset, versions: Versions): Promise<boolean> {
-  const exists = fs.existsSync(asset.dest);
-  const stored = versions[asset.id] ?? {};
-  const canValidate = Boolean(stored.etag || stored.lastModified);
+async function ensureAsset(
+  plan: AssetPlan,
+  versions: Versions,
+): Promise<boolean> {
+  const exists = fs.existsSync(plan.dest);
+  const stored = versions[plan.id];
+  const stale = exists ? isStale(mtimeMs(plan.dest), Date.now()) : true;
 
   // Without a stored validator we cannot make a conditional request, so a plain
   // GET would re-download every launch. Skip until the cached copy is stale.
-  if (exists && !canValidate && !isStale(asset.dest)) {
+  if (canSkipUnvalidated(exists, stored, stale)) {
     return false;
-  }
-
-  const headers: Record<string, string> = {};
-  if (exists && stored.etag) {
-    headers["If-None-Match"] = stored.etag;
-  }
-  if (exists && stored.lastModified) {
-    headers["If-Modified-Since"] = stored.lastModified;
   }
 
   let res: FetchResponse;
   try {
-    res = await fetchAsset(asset.url, headers, 5);
+    res = await fetchAsset(plan.url, conditionalHeaders(exists, stored), 5);
   } catch (err) {
     // Offline or the server is unreachable. Keep whatever we already have; only
     // fail if there is nothing cached to fall back on.
     if (exists) {
-      console.error(`Keeping cached ${asset.id}; version check failed: ${err}`);
+      console.error(`Keeping cached ${plan.id}; version check failed: ${err}`);
       return false;
     }
     throw err;
@@ -302,15 +189,15 @@ async function ensureAsset(asset: Asset, versions: Versions): Promise<boolean> {
     path.join(os.tmpdir(), "karafriends_externalResources"),
   );
   try {
-    const src = await asset.materialize(tmpDir, res);
-    await finalize(src, asset.dest);
+    const src = await materialize(plan, tmpDir, res);
+    await finalize(src, plan.dest);
     if (process.platform !== "win32") {
-      fs.chmodSync(asset.dest, 0o755);
+      fs.chmodSync(plan.dest, 0o755);
     }
   } catch (err) {
     // A failed refresh must not destroy a working cached copy.
     if (exists) {
-      console.error(`Keeping cached ${asset.id}; update failed: ${err}`);
+      console.error(`Keeping cached ${plan.id}; update failed: ${err}`);
       return false;
     }
     throw err;
@@ -318,7 +205,7 @@ async function ensureAsset(asset: Asset, versions: Versions): Promise<boolean> {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 
-  versions[asset.id] = {
+  versions[plan.id] = {
     etag: res.headers.get("etag") ?? undefined,
     lastModified: res.headers.get("last-modified") ?? undefined,
   };
@@ -326,11 +213,11 @@ async function ensureAsset(asset: Asset, versions: Versions): Promise<boolean> {
 }
 
 async function doEnsure(): Promise<void> {
-  const assets = platformAssets();
+  const plans = assetPlans(process.platform, resourcePaths);
   const versions = readVersions();
 
   const changed = await Promise.all(
-    assets.map((asset) => ensureAsset(asset, versions)),
+    plans.map((plan) => ensureAsset(plan, versions)),
   );
 
   if (changed.some(Boolean)) {

--- a/src/common/externalResourcesPlan.test.ts
+++ b/src/common/externalResourcesPlan.test.ts
@@ -1,0 +1,232 @@
+// This file runs on Node's built-in test runner, not through the app bundle, so
+// it uses node: core modules directly.
+/* tslint:disable:no-submodule-imports no-implicit-dependencies */
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "node:test";
+
+import {
+  assetPlans,
+  canSkipUnvalidated,
+  conditionalHeaders,
+  extractorFileName,
+  hasValidator,
+  isStale,
+  resourcePathsFor,
+  STALE_MS,
+  type Platform,
+} from "./externalResourcesPlan.ts";
+
+const PLATFORMS: Platform[] = ["win32", "darwin", "linux"];
+
+// Per-platform expectations. These encode the cross-platform contract: the
+// binary filenames, download URLs, and unpacking each OS needs.
+const EXPECT: Record<
+  string,
+  {
+    extractor: string;
+    ffmpeg: string;
+    ytdlp: string;
+    ytdlpUrl: string;
+    ffmpegUrl: string;
+    archiveName: string;
+    steps: number;
+    binary: string[];
+  }
+> = {
+  win32: {
+    extractor: "7za.exe",
+    ffmpeg: "ffmpeg.exe",
+    ytdlp: "yt-dlp.exe",
+    ytdlpUrl:
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
+    ffmpegUrl: "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
+    archiveName: "ffmpeg.7z",
+    steps: 1,
+    binary: ["out", "ffmpeg.exe"],
+  },
+  darwin: {
+    extractor: "7za",
+    ffmpeg: "ffmpeg",
+    ytdlp: "yt-dlp_macos",
+    ytdlpUrl:
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
+    ffmpegUrl: "https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip",
+    archiveName: "ffmpeg.zip",
+    steps: 1,
+    binary: ["out", "ffmpeg"],
+  },
+  linux: {
+    extractor: "7za",
+    ffmpeg: "ffmpeg",
+    ytdlp: "yt-dlp",
+    ytdlpUrl:
+      "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp",
+    ffmpegUrl:
+      "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
+    archiveName: "ffmpeg.tar.xz",
+    steps: 2,
+    binary: ["out", "ffmpeg"],
+  },
+};
+
+describe("extractorFileName", () => {
+  test("uses the .exe extractor on Windows and the bare name elsewhere", () => {
+    assert.equal(extractorFileName("win32"), "7za.exe");
+    assert.equal(extractorFileName("darwin"), "7za");
+    assert.equal(extractorFileName("linux"), "7za");
+  });
+});
+
+describe("resourcePathsFor", () => {
+  for (const platform of PLATFORMS) {
+    test(`resolves cached binary paths for ${platform}`, () => {
+      const cacheDir = path.join("cache", "dir");
+      const paths = resourcePathsFor(platform, cacheDir);
+      const expected = EXPECT[platform];
+
+      assert.equal(
+        paths.ffmpeg,
+        path.join(cacheDir, "ffmpeg", expected.ffmpeg),
+      );
+      assert.equal(paths.ytdlp, path.join(cacheDir, "ytdlp", expected.ytdlp));
+    });
+  }
+});
+
+describe("assetPlans", () => {
+  for (const platform of PLATFORMS) {
+    const expected = EXPECT[platform];
+    const paths = resourcePathsFor(platform, path.join("cache", "dir"));
+    const plans = assetPlans(platform, paths);
+
+    test(`${platform}: has a ytdlp binary asset and an ffmpeg archive asset`, () => {
+      assert.deepEqual(
+        plans.map((p) => p.id),
+        ["ytdlp", "ffmpeg"],
+      );
+    });
+
+    test(`${platform}: plan destinations match resourcePathsFor`, () => {
+      const byId = Object.fromEntries(plans.map((p) => [p.id, p]));
+      assert.equal(byId.ytdlp.dest, paths.ytdlp);
+      assert.equal(byId.ffmpeg.dest, paths.ffmpeg);
+    });
+
+    test(`${platform}: ytdlp is a direct binary download from the expected URL`, () => {
+      const ytdlp = plans.find((p) => p.id === "ytdlp")!;
+      assert.equal(ytdlp.download.kind, "binary");
+      assert.equal(ytdlp.url, expected.ytdlpUrl);
+    });
+
+    test(`${platform}: ffmpeg is an archive unpacked to the ffmpeg binary`, () => {
+      const ffmpeg = plans.find((p) => p.id === "ffmpeg")!;
+      assert.equal(ffmpeg.url, expected.ffmpegUrl);
+      assert.equal(ffmpeg.download.kind, "archive");
+
+      if (ffmpeg.download.kind !== "archive") return; // narrow for the type checker
+      const dl = ffmpeg.download;
+
+      assert.equal(dl.archiveName, expected.archiveName);
+      assert.equal(dl.steps.length, expected.steps);
+      assert.equal(dl.binary, path.join(...expected.binary));
+
+      // The first pass consumes the downloaded archive, and the final pass
+      // produces the directory the binary is read from.
+      assert.equal(dl.steps[0].input, dl.archiveName);
+      assert.equal(
+        dl.steps[dl.steps.length - 1].outDir,
+        path.dirname(dl.binary),
+      );
+    });
+
+    test(`${platform}: every asset URL is https`, () => {
+      for (const plan of plans) {
+        assert.ok(
+          plan.url.startsWith("https://"),
+          `${plan.id} url should be https: ${plan.url}`,
+        );
+      }
+    });
+  }
+});
+
+describe("conditionalHeaders", () => {
+  test("sends no headers when the file is not cached", () => {
+    assert.deepEqual(conditionalHeaders(false, undefined), {});
+    assert.deepEqual(conditionalHeaders(false, { etag: "abc" }), {});
+  });
+
+  test("sends no headers when there is no stored validator", () => {
+    assert.deepEqual(conditionalHeaders(true, undefined), {});
+    assert.deepEqual(conditionalHeaders(true, {}), {});
+  });
+
+  test("sends If-None-Match for a stored etag", () => {
+    assert.deepEqual(conditionalHeaders(true, { etag: "abc" }), {
+      "If-None-Match": "abc",
+    });
+  });
+
+  test("sends If-Modified-Since for a stored last-modified", () => {
+    assert.deepEqual(conditionalHeaders(true, { lastModified: "Mon" }), {
+      "If-Modified-Since": "Mon",
+    });
+  });
+
+  test("sends both validators when both are stored", () => {
+    assert.deepEqual(
+      conditionalHeaders(true, { etag: "abc", lastModified: "Mon" }),
+      { "If-None-Match": "abc", "If-Modified-Since": "Mon" },
+    );
+  });
+});
+
+describe("hasValidator", () => {
+  test("is true only when an etag or last-modified is present", () => {
+    assert.equal(hasValidator(undefined), false);
+    assert.equal(hasValidator({}), false);
+    assert.equal(hasValidator({ etag: "abc" }), true);
+    assert.equal(hasValidator({ lastModified: "Mon" }), true);
+  });
+});
+
+describe("canSkipUnvalidated", () => {
+  test("never skips when the file is missing", () => {
+    assert.equal(canSkipUnvalidated(false, undefined, false), false);
+    assert.equal(canSkipUnvalidated(false, { etag: "abc" }, false), false);
+  });
+
+  test("skips a fresh cached file that has no validator", () => {
+    assert.equal(canSkipUnvalidated(true, undefined, false), true);
+    assert.equal(canSkipUnvalidated(true, {}, false), true);
+  });
+
+  test("does not skip a stale cached file that has no validator", () => {
+    assert.equal(canSkipUnvalidated(true, undefined, true), false);
+  });
+
+  test("does not skip when a validator exists (a conditional request is cheap)", () => {
+    assert.equal(canSkipUnvalidated(true, { etag: "abc" }, false), false);
+    assert.equal(canSkipUnvalidated(true, { etag: "abc" }, true), false);
+  });
+});
+
+describe("isStale", () => {
+  test("is a one week window", () => {
+    assert.equal(STALE_MS, 7 * 24 * 60 * 60 * 1000);
+  });
+
+  test("is true only once older than the window", () => {
+    const now = 10 * STALE_MS;
+    assert.equal(isStale(now - STALE_MS - 1, now), true);
+    assert.equal(isStale(now - STALE_MS, now), false);
+    assert.equal(isStale(now - 1, now), false);
+    assert.equal(isStale(now, now), false);
+  });
+
+  test("honours a custom window", () => {
+    assert.equal(isStale(0, 100, 50), true);
+    assert.equal(isStale(60, 100, 50), false);
+  });
+});

--- a/src/common/externalResourcesPlan.ts
+++ b/src/common/externalResourcesPlan.ts
@@ -1,0 +1,194 @@
+import path from "path";
+
+// Pure, dependency-free planning and decision logic for the external runtime
+// binaries. It is kept separate from externalResources.ts (which touches
+// electron, the filesystem and the network) so the cross-platform behaviour can
+// be unit tested without any of those side effects.
+
+export type Platform = NodeJS.Platform;
+
+export interface ResourcePaths {
+  // Path to the ffmpeg executable
+  ffmpeg: string;
+  // Path to the ytdlp executable
+  ytdlp: string;
+}
+
+// An HTTP cache validator for a downloaded asset. Persisted between launches so
+// we can make a conditional request and skip the download when it is unchanged.
+export interface Validator {
+  etag?: string;
+  lastModified?: string;
+}
+
+export type Versions = Record<string, Validator>;
+
+// One extraction pass: unpack `input` (relative to the temp dir) into `outDir`
+// (relative to the temp dir). Archives that need multiple passes (e.g. .tar.xz)
+// list several steps, each consuming a file produced by the previous one.
+export interface ExtractStep {
+  input: string;
+  outDir: string;
+}
+
+export type Download =
+  | { kind: "binary" }
+  | {
+      kind: "archive";
+      // Temp filename to stream the downloaded archive into.
+      archiveName: string;
+      steps: ExtractStep[];
+      // Path of the extracted binary, relative to the temp dir.
+      binary: string;
+    };
+
+export interface AssetPlan {
+  id: "ytdlp" | "ffmpeg";
+  url: string;
+  dest: string;
+  download: Download;
+}
+
+// Refresh the cached copy once it is older than this when the server exposes no
+// cache validators, so it neither re-downloads on every launch nor goes stale
+// forever.
+export const STALE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const YTDLP_BASE =
+  "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp";
+
+export function extractorFileName(platform: Platform): string {
+  return platform === "win32" ? "7za.exe" : "7za";
+}
+
+export function resourcePathsFor(
+  platform: Platform,
+  cacheDir: string,
+): ResourcePaths {
+  const ffmpegName = platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
+  const ytdlpName =
+    platform === "win32"
+      ? "yt-dlp.exe"
+      : platform === "darwin"
+        ? "yt-dlp_macos"
+        : "yt-dlp";
+  return {
+    ffmpeg: path.join(cacheDir, "ffmpeg", ffmpegName),
+    ytdlp: path.join(cacheDir, "ytdlp", ytdlpName),
+  };
+}
+
+// The downloadable assets for a platform: their URLs, final destinations, and
+// how (if at all) each download is unpacked.
+export function assetPlans(
+  platform: Platform,
+  paths: ResourcePaths,
+): AssetPlan[] {
+  switch (platform) {
+    case "win32":
+      return [
+        {
+          id: "ytdlp",
+          url: `${YTDLP_BASE}.exe`,
+          dest: paths.ytdlp,
+          download: { kind: "binary" },
+        },
+        {
+          id: "ffmpeg",
+          url: "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
+          dest: paths.ffmpeg,
+          download: {
+            kind: "archive",
+            archiveName: "ffmpeg.7z",
+            steps: [{ input: "ffmpeg.7z", outDir: "out" }],
+            binary: path.join("out", "ffmpeg.exe"),
+          },
+        },
+      ];
+    case "darwin":
+      return [
+        {
+          id: "ytdlp",
+          url: `${YTDLP_BASE}_macos`,
+          dest: paths.ytdlp,
+          download: { kind: "binary" },
+        },
+        {
+          id: "ffmpeg",
+          url: "https://evermeet.cx/ffmpeg/ffmpeg-6.1.1.zip",
+          dest: paths.ffmpeg,
+          download: {
+            kind: "archive",
+            archiveName: "ffmpeg.zip",
+            steps: [{ input: "ffmpeg.zip", outDir: "out" }],
+            binary: path.join("out", "ffmpeg"),
+          },
+        },
+      ];
+    default:
+      return [
+        {
+          id: "ytdlp",
+          url: YTDLP_BASE,
+          dest: paths.ytdlp,
+          download: { kind: "binary" },
+        },
+        {
+          id: "ffmpeg",
+          // GitHub-hosted static build; johnvansickle.com resets connections
+          // from some IPs. Flat extraction still yields the ffmpeg binary.
+          url: "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
+          dest: paths.ffmpeg,
+          download: {
+            kind: "archive",
+            archiveName: "ffmpeg.tar.xz",
+            // .tar.xz needs two passes: first to the .tar, then to the contents.
+            steps: [
+              { input: "ffmpeg.tar.xz", outDir: "tar" },
+              { input: path.join("tar", "ffmpeg.tar"), outDir: "out" },
+            ],
+            binary: path.join("out", "ffmpeg"),
+          },
+        },
+      ];
+  }
+}
+
+export function hasValidator(stored: Validator | undefined): boolean {
+  return Boolean(stored?.etag || stored?.lastModified);
+}
+
+// Conditional-request headers for an asset we already have on disk, so the
+// server can answer 304 Not Modified when the cached copy is still current.
+export function conditionalHeaders(
+  exists: boolean,
+  stored: Validator | undefined,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (exists && stored?.etag) {
+    headers["If-None-Match"] = stored.etag;
+  }
+  if (exists && stored?.lastModified) {
+    headers["If-Modified-Since"] = stored.lastModified;
+  }
+  return headers;
+}
+
+export function isStale(
+  mtimeMs: number,
+  nowMs: number,
+  staleMs: number = STALE_MS,
+): boolean {
+  return nowMs - mtimeMs > staleMs;
+}
+
+// Whether the network can be skipped entirely: the file is present, there is no
+// validator to make a conditional request with, and the cached copy is fresh.
+// Downloading anyway would re-fetch the asset on every launch.
+export function canSkipUnvalidated(
+  exists: boolean,
+  stored: Validator | undefined,
+  stale: boolean,
+): boolean {
+  return exists && !hasValidator(stored) && !stale;
+}

--- a/src/common/videoDownloader.ts
+++ b/src/common/videoDownloader.ts
@@ -13,22 +13,11 @@ import {
 } from "../main/graphql";
 import { JoysoundAPI, JoysoundSongRawData } from "../main/joysoundApi";
 
+import { ensureExternalResources, getResourcePaths } from "./externalResources";
 import { getSongDuration } from "./joysoundParser";
 
 export const TEMP_FOLDER: string = `${app.getPath("temp")}/karafriends_tmp`;
 const captionCodeRe: RegExp = new RegExp(/^[a-z]{2}$/);
-
-const extraResourcesPath: string =
-  process.env.NODE_ENV === "development"
-    ? `${app.getAppPath()}/../../../extraResources/`
-    : `${process.resourcesPath}/extraResources/`;
-
-interface ResourcePaths {
-  // Path to the directory containing the ffmpeg executable
-  ffmpeg: string;
-  // Path to the ytdlp executable
-  ytdlp: string;
-}
 
 interface JoysoundVideoData {
   songId: string;
@@ -38,27 +27,7 @@ interface JoysoundVideoData {
   oggBuffer: Buffer;
 }
 
-const linuxResourcePaths: ResourcePaths = {
-  ffmpeg: `${extraResourcesPath}ffmpeg/linux/ffmpeg`,
-  ytdlp: `${extraResourcesPath}/ytdlp/yt-dlp`,
-};
-
-const macosResourcePaths: ResourcePaths = {
-  ffmpeg: `${extraResourcesPath}ffmpeg/macos/ffmpeg`,
-  ytdlp: `${extraResourcesPath}ytdlp/yt-dlp_macos`,
-};
-
-const winResourcePaths: ResourcePaths = {
-  ffmpeg: `${extraResourcesPath}ffmpeg/win/ffmpeg.exe`,
-  ytdlp: `${extraResourcesPath}ytdlp/yt-dlp.exe`,
-};
-
-const resourcePaths: ResourcePaths =
-  process.platform === "win32"
-    ? winResourcePaths
-    : process.platform === "darwin"
-    ? macosResourcePaths
-    : linuxResourcePaths;
+const resourcePaths = getResourcePaths();
 
 function deleteTempFiles(prefix: string): void {
   for (const filename of fs.readdirSync(TEMP_FOLDER)) {
@@ -75,7 +44,7 @@ function deleteTempFiles(prefix: string): void {
 function handleFFmpegDownloadLog(
   log: string,
   songFrames: number,
-  downloadQueueItem: DownloadQueueItem
+  downloadQueueItem: DownloadQueueItem,
 ): void {
   const frameMatchData = log.match(/frame=\s*(\d+)\s*/);
 
@@ -89,7 +58,7 @@ function handleFFmpegDownloadLog(
 
 function handleYoutubeDownloadLog(
   log: string,
-  downloadQueueItem: DownloadQueueItem
+  downloadQueueItem: DownloadQueueItem,
 ): void {
   const matchData = log.match(/\[download\]\s*(\d+\.\d)%/);
 
@@ -105,7 +74,7 @@ function isVideoCurrentlyDownloading(
   downloadQueue: DownloadQueueItem[],
   downloadType: number,
   songId: string,
-  suffix: string | null = null
+  suffix: string | null = null,
 ): boolean {
   if (!fs.existsSync(filename)) {
     return false;
@@ -115,7 +84,7 @@ function isVideoCurrentlyDownloading(
     (item) =>
       item.downloadType === downloadType &&
       item.songId === songId &&
-      item.suffix === suffix
+      item.suffix === suffix,
   );
 
   return Boolean(prevDownloadQueueItem);
@@ -125,13 +94,13 @@ export function getVideoDownloadProgress(
   downloadQueue: DownloadQueueItem[],
   downloadType: number,
   songId: string,
-  suffix: string | null = null
+  suffix: string | null = null,
 ): number {
   const downloadQueueItem = downloadQueue.find(
     (item) =>
       item.downloadType === downloadType &&
       item.songId === songId &&
-      item.suffix === suffix
+      item.suffix === suffix,
   );
 
   if (downloadQueueItem) {
@@ -143,7 +112,7 @@ export function getVideoDownloadProgress(
 
 function removeVideoDownloadFromQueue(
   downloadQueue: DownloadQueueItem[],
-  downloadQueueItem: DownloadQueueItem
+  downloadQueueItem: DownloadQueueItem,
 ): void {
   downloadQueue.splice(downloadQueue.indexOf(downloadQueueItem), 1);
 }
@@ -182,7 +151,7 @@ function getJoysoundOggPlaytime(oggBuffer: Buffer): number {
 
   const playtimeBuffer = oggBuffer.subarray(
     fieldOffset,
-    fieldOffset + fieldLength
+    fieldOffset + fieldLength,
   );
 
   let playtimeString = "";
@@ -197,7 +166,19 @@ function getJoysoundOggPlaytime(oggBuffer: Buffer): number {
 export function downloadDamVideo(
   m3u8Url: string,
   songId: string,
-  suffix: string
+  suffix: string,
+): void {
+  ensureExternalResources()
+    .then(() => downloadDamVideoImpl(m3u8Url, songId, suffix))
+    .catch((err) =>
+      console.error(`Error preparing external resources: ${err}`),
+    );
+}
+
+function downloadDamVideoImpl(
+  m3u8Url: string,
+  songId: string,
+  suffix: string,
 ): void {
   if (!fs.existsSync(TEMP_FOLDER)) {
     fs.mkdirSync(TEMP_FOLDER);
@@ -230,7 +211,7 @@ export function downloadDamVideo(
       "mp4",
       tempFilename,
     ],
-    { stdio: ["ignore", "pipe", "pipe"] }
+    { stdio: ["ignore", "pipe", "pipe"] },
   );
 
   invariant(ffmpeg.stdout);
@@ -245,7 +226,7 @@ export function downloadDamVideo(
       fs.renameSync(tempFilename, filename);
     } else {
       console.error(
-        `Error downloading DAM video with ID ${songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+        `Error downloading DAM video with ID ${songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
       );
     }
   });
@@ -257,7 +238,7 @@ function makeJoysoundFFmpegCall(
   ffmpegLogFilename: string,
   onStderrData: null | ((data: Buffer) => any),
   onExit: null | ((code: number, signal: number) => any),
-  stdinBuffer: Buffer | string | null
+  stdinBuffer: Buffer | string | null,
 ): void {
   const ffmpegLogStream = fs.createWriteStream(ffmpegLogFilename, {
     flags: "a",
@@ -296,7 +277,7 @@ function downloadJoysoundVideoPromise(
   downloadQueue: DownloadQueueItem[],
   downloadQueueItem: DownloadQueueItem,
   tempFilename: string,
-  ffmpegLogFilename: string
+  ffmpegLogFilename: string,
 ): Promise<number> {
   return new Promise((resolve, reject) => {
     let songFrames = 0;
@@ -318,7 +299,7 @@ function downloadJoysoundVideoPromise(
       const ffmpegLog = ffmpegData.toString();
 
       const durationMatchData = ffmpegLog.match(
-        /Duration:\s*(\d+):(\d+):(\d+)/
+        /Duration:\s*(\d+):(\d+):(\d+)/,
       );
 
       if (durationMatchData) {
@@ -341,7 +322,7 @@ function downloadJoysoundVideoPromise(
         resolve(code);
       } else {
         console.error(
-          `Error downloading Joysound video with ID ${songId}: url=${videoUrl}, code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+          `Error downloading Joysound video with ID ${songId}: url=${videoUrl}, code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
         );
 
         reject(code);
@@ -354,7 +335,7 @@ function downloadJoysoundVideoPromise(
       ffmpegLogFilename,
       onStderrData,
       onExit,
-      null
+      null,
     );
   });
 }
@@ -364,7 +345,7 @@ function downloadJoysoundYoutubeVideoPromise(
   youtubeVideoId: string,
   downloadQueue: DownloadQueueItem[],
   downloadQueueItem: DownloadQueueItem,
-  tempFilename: string
+  tempFilename: string,
 ): Promise<number> {
   return new Promise((resolve, reject) => {
     const ytdlpLogFilename = `${TEMP_FOLDER}/yt-${youtubeVideoId}.log`;
@@ -395,7 +376,7 @@ function downloadJoysoundYoutubeVideoPromise(
       {
         env,
         stdio: ["ignore", "pipe", "pipe"],
-      }
+      },
     );
 
     invariant(ytdlp.stdout);
@@ -420,7 +401,7 @@ function downloadJoysoundYoutubeVideoPromise(
         resolve(code);
       } else {
         console.error(
-          `Error downloading Youtube Video with ID ${youtubeVideoId}: code=${code}, signal=${signal}, log=${ytdlpLogFilename}`
+          `Error downloading Youtube Video with ID ${youtubeVideoId}: code=${code}, signal=${signal}, log=${ytdlpLogFilename}`,
         );
         reject(code);
       }
@@ -434,7 +415,7 @@ function composeJoysoundVideoPromise(
   oggBuffer: Buffer,
   tempFilename: string,
   videoFilename: string,
-  ffmpegLogFilename: string
+  ffmpegLogFilename: string,
 ): Promise<JoysoundVideoData> {
   return new Promise((resolve, reject) => {
     let videoPlaytime = 0;
@@ -460,7 +441,7 @@ function composeJoysoundVideoPromise(
       const ffmpegLog = ffmpegData.toString();
 
       const durationMatchData = ffmpegLog.match(
-        /Duration:\s*(\d+):(\d+):(\d+)\.(\d+)/
+        /Duration:\s*(\d+):(\d+):(\d+)\.(\d+)/,
       );
 
       // XXX: We assume that the video duration always comes first
@@ -488,7 +469,7 @@ function composeJoysoundVideoPromise(
         resolve(metadata);
       } else {
         console.error(
-          `Error downloading Joysound video with ID ${songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+          `Error downloading Joysound video with ID ${songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
         );
 
         reject(code);
@@ -501,7 +482,7 @@ function composeJoysoundVideoPromise(
       ffmpegLogFilename,
       onStderrData,
       onExit,
-      oggBuffer
+      oggBuffer,
     );
   });
 }
@@ -514,8 +495,8 @@ function padJoysoundVideoPromise(
   pushToHead: boolean,
   pushSongToQueue: (
     queueItem: JoysoundQueueItem,
-    pushToHead: boolean
-  ) => QueueSongResult
+    pushToHead: boolean,
+  ) => QueueSongResult,
 ): Promise<number> {
   const videoBaseFilename = videoFilename.substr(0, videoFilename.length - 4);
 
@@ -543,7 +524,7 @@ function padJoysoundVideoPromise(
         resolve(code);
       } else {
         console.error(
-          `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+          `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
         );
 
         reject(code);
@@ -556,7 +537,7 @@ function padJoysoundVideoPromise(
       ffmpegLogFilename,
       null,
       onExit,
-      null
+      null,
     );
   })
     .then(() => {
@@ -578,7 +559,7 @@ function padJoysoundVideoPromise(
             resolve(code);
           } else {
             console.error(
-              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
             );
 
             reject(code);
@@ -591,7 +572,7 @@ function padJoysoundVideoPromise(
           ffmpegLogFilename,
           null,
           onExit,
-          null
+          null,
         );
       });
     })
@@ -617,7 +598,7 @@ function padJoysoundVideoPromise(
             resolve(code);
           } else {
             console.error(
-              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
             );
 
             reject(code);
@@ -630,7 +611,7 @@ function padJoysoundVideoPromise(
           ffmpegLogFilename,
           null,
           onExit,
-          null
+          null,
         );
       });
     })
@@ -662,7 +643,7 @@ function padJoysoundVideoPromise(
             resolve(code);
           } else {
             console.error(
-              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
             );
 
             reject(code);
@@ -675,7 +656,7 @@ function padJoysoundVideoPromise(
           ffmpegLogFilename,
           null,
           onExit,
-          null
+          null,
         );
       });
     })
@@ -713,7 +694,7 @@ function padJoysoundVideoPromise(
             resolve(code);
           } else {
             console.error(
-              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`
+              `Error downloading Joysound video with ID ${data.songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
             );
 
             reject(code);
@@ -726,7 +707,7 @@ function padJoysoundVideoPromise(
           ffmpegLogFilename,
           null,
           onExit,
-          null
+          null,
         );
       });
     });
@@ -740,8 +721,35 @@ export function downloadJoysoundData(
   pushToHead: boolean,
   pushSongToQueue: (
     queueItem: JoysoundQueueItem,
-    pushToHead: boolean
-  ) => QueueSongResult
+    pushToHead: boolean,
+  ) => QueueSongResult,
+): void {
+  ensureExternalResources()
+    .then(() =>
+      downloadJoysoundDataImpl(
+        downloadQueue,
+        userIdentity,
+        joysoundApi,
+        queueItem,
+        pushToHead,
+        pushSongToQueue,
+      ),
+    )
+    .catch((err) =>
+      console.error(`Error preparing external resources: ${err}`),
+    );
+}
+
+function downloadJoysoundDataImpl(
+  downloadQueue: DownloadQueueItem[],
+  userIdentity: UserIdentity,
+  joysoundApi: JoysoundAPI,
+  queueItem: JoysoundQueueItem,
+  pushToHead: boolean,
+  pushSongToQueue: (
+    queueItem: JoysoundQueueItem,
+    pushToHead: boolean,
+  ) => QueueSongResult,
 ): void {
   if (!fs.existsSync(TEMP_FOLDER)) {
     fs.mkdirSync(TEMP_FOLDER);
@@ -777,7 +785,7 @@ export function downloadJoysoundData(
       return;
     } else {
       console.error(
-        `${videoFilename} already exists, but ${telopFilename} does not.`
+        `${videoFilename} already exists, but ${telopFilename} does not.`,
       );
 
       fs.unlinkSync(videoFilename);
@@ -790,7 +798,7 @@ export function downloadJoysoundData(
       downloadQueue,
       0,
       songId,
-      queueItem.youtubeVideoId
+      queueItem.youtubeVideoId,
     )
   ) {
     console.error(`${videoFilename} was already queued, not redownloading`);
@@ -823,7 +831,7 @@ export function downloadJoysoundData(
       queueItem.youtubeVideoId,
       downloadQueue,
       downloadQueueItem,
-      tempFilename
+      tempFilename,
     );
   } else {
     videoDataPromise = joysoundApi.getMovieUrls(songId).then((data) => {
@@ -835,7 +843,7 @@ export function downloadJoysoundData(
         downloadQueue,
         downloadQueueItem,
         tempFilename,
-        ffmpegLogFilename
+        ffmpegLogFilename,
       );
     });
   }
@@ -851,12 +859,12 @@ export function downloadJoysoundData(
 
       const telopBuffer = Buffer.from(
         telopBase64.slice(30) + telopBase64.slice(0, 30),
-        "base64"
+        "base64",
       );
 
       const oggBuffer = Buffer.from(
         oggBase64.slice(30) + oggBase64.slice(0, 30),
-        "base64"
+        "base64",
       );
 
       if (!fs.existsSync(telopFilename)) {
@@ -869,7 +877,7 @@ export function downloadJoysoundData(
         oggBuffer,
         tempFilename,
         videoFilename,
-        ffmpegLogFilename
+        ffmpegLogFilename,
       );
     })
     .then((data) => {
@@ -888,7 +896,7 @@ export function downloadJoysoundData(
           ffmpegLogFilename,
           queueItem,
           pushToHead,
-          pushSongToQueue
+          pushSongToQueue,
         );
       } else {
         pushSongToQueue(queueItem, pushToHead);
@@ -901,11 +909,33 @@ export function downloadYoutubeVideo(
   userIdentity: UserIdentity,
   videoId: string,
   captionCode: string | null,
-  onComplete: () => any
+  onComplete: () => any,
+): void {
+  ensureExternalResources()
+    .then(() =>
+      downloadYoutubeVideoImpl(
+        downloadQueue,
+        userIdentity,
+        videoId,
+        captionCode,
+        onComplete,
+      ),
+    )
+    .catch((err) =>
+      console.error(`Error preparing external resources: ${err}`),
+    );
+}
+
+function downloadYoutubeVideoImpl(
+  downloadQueue: DownloadQueueItem[],
+  userIdentity: UserIdentity,
+  videoId: string,
+  captionCode: string | null,
+  onComplete: () => any,
 ): void {
   if (captionCode !== null && !captionCodeRe.test(captionCode)) {
     console.error(
-      `Error downloading Youtube Video. ${captionCode} is not a valid caption code`
+      `Error downloading Youtube Video. ${captionCode} is not a valid caption code`,
     );
     return;
   }
@@ -970,7 +1000,7 @@ export function downloadYoutubeVideo(
       "--",
       videoId,
     ],
-    { stdio: ["ignore", "pipe", "pipe"] }
+    { stdio: ["ignore", "pipe", "pipe"] },
   );
 
   invariant(ytdlp.stdout);
@@ -992,7 +1022,7 @@ export function downloadYoutubeVideo(
 
     if (code !== 0) {
       console.error(
-        `Error downloading Youtube Video with ID ${videoId}: code=${code}, signal=${signal}, log=${ytdlpLogFilename}`
+        `Error downloading Youtube Video with ID ${videoId}: code=${code}, signal=${signal}, log=${ytdlpLogFilename}`,
       );
       return;
     }
@@ -1002,7 +1032,7 @@ export function downloadYoutubeVideo(
         fs.renameSync(`${writeBasePath}.${captionCode}.vtt`, vttFilename);
       } catch (fsError) {
         console.error(
-          `Error trying to rename caption file ${writeBasePath}.${captionCode}.vtt to ${writeBasePath}.vtt: ${fsError}`
+          `Error trying to rename caption file ${writeBasePath}.${captionCode}.vtt to ${writeBasePath}.vtt: ${fsError}`,
         );
       }
     }
@@ -1015,7 +1045,22 @@ export function downloadNicoVideo(
   downloadQueue: DownloadQueueItem[],
   userIdentity: UserIdentity,
   videoId: string,
-  onComplete: () => any
+  onComplete: () => any,
+): void {
+  ensureExternalResources()
+    .then(() =>
+      downloadNicoVideoImpl(downloadQueue, userIdentity, videoId, onComplete),
+    )
+    .catch((err) =>
+      console.error(`Error preparing external resources: ${err}`),
+    );
+}
+
+function downloadNicoVideoImpl(
+  downloadQueue: DownloadQueueItem[],
+  userIdentity: UserIdentity,
+  videoId: string,
+  onComplete: () => any,
 ): void {
   if (!fs.existsSync(TEMP_FOLDER)) {
     fs.mkdirSync(TEMP_FOLDER);
@@ -1072,7 +1117,7 @@ export function downloadNicoVideo(
     {
       env,
       stdio: ["ignore", "pipe", "pipe"],
-    }
+    },
   );
 
   invariant(ytdlp.stdout);
@@ -1096,7 +1141,7 @@ export function downloadNicoVideo(
       onComplete();
     } else {
       console.error(
-        `Error downloading Niconico Video with ID ${videoId}: code=${code}, signal=${signal}, log=${ytdlpLogFilename}`
+        `Error downloading Niconico Video with ID ${videoId}: code=${code}, signal=${signal}, log=${ytdlpLogFilename}`,
       );
     }
   });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,7 @@ import isDev from "electron-is-dev";
 import express from "express";
 
 import karafriendsConfig from "../common/config";
+import { ensureExternalResources } from "./../common/externalResources";
 import { TEMP_FOLDER } from "./../common/videoDownloader";
 import { MinseiAPI } from "./damApi";
 import { applyGraphQLMiddleware } from "./graphql";
@@ -155,7 +156,16 @@ function createWindow() {
   });
 }
 
-app.on("ready", createWindow);
+app.on("ready", () => {
+  // Start warming the external resource cache as soon as the app is ready so
+  // the binaries are usually in place before the first song is queued. This is
+  // best-effort: failures are logged and retried on demand by the downloader,
+  // and must be caught here so the unhandledRejection handler doesn't exit.
+  ensureExternalResources().catch((err) =>
+    console.error(`Error preparing external resources: ${err}`),
+  );
+  createWindow();
+});
 
 app.on("window-all-closed", () => {
   app.quit();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
     "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "jsx": "react"
-  }
+  },
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
## What

The external media tooling binaries were fetched and unpacked at **build time** and bundled into every packaged app. This PR moves that work to **runtime**: the app downloads the binaries lazily on the user's machine, caches them in the per-user data directory, and reuses them across launches.

## Why

- Bundling the binaries bloated every build and packaged artifact, and they went stale between releases since they are large, frequently-updated, platform-specific tools.
- It required a special macOS code-signing carve-out for a bundled binary that loads its own libraries.
- CI had to cache/fetch them on every run.

## How

- New main-process module `src/common/externalResources.ts` downloads, extracts, caches, and resolves paths for the runtime binaries. `ensureExternalResources()` is idempotent (single in-flight promise), short-circuits when the cache is already populated, downloads to a temp dir, and atomically moves finished binaries into `<userData>/externalResources` so an interrupted download never leaves a valid-looking file.
- `videoDownloader.ts` now reads paths from `getResourcePaths()` and gates each download entry point on `ensureExternalResources()`.
- `index.ts` warms the cache at app startup (best-effort; errors are caught so the `unhandledRejection` handler can't exit the app).
- The build script (`scripts/getExternalResources.mjs`) no longer downloads the large binaries. It only stages the small, stable archive **extractor** (needed at runtime to unpack the downloads) plus the Windows ASIO SDK, which stays a build-time native compile-time dependency.
- `packager.js` bundles the target-arch extractor and drops the now-unneeded signing carve-out.
- CI no longer caches the large resources.

## Verification

- Type-check is clean for the new/changed code (no new errors vs. `master`); a full `parcel` build of all targets succeeds with the new module bundled; the build script stages the extractor offline; lint/format hooks pass.
- **Recommended manual check:** on a clean machine, launch the app and confirm the binaries download into the per-user cache on first run, a queued song downloads and plays, and a second launch reuses the cache without re-downloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)