### PR TITLE
Harden main-process crash paths

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -79,17 +79,35 @@ function getConfig(): KarafriendsConfig {
 
   if (fs.existsSync(configFilepath)) {
     console.log(`Configs found. Loading them up.`);
-    const localConfig: KarafriendsConfig = parse(
-      fs.readFileSync(configFilepath, { encoding: "utf8", flag: "r" }),
-    );
-    config = { ...DEFAULT_CONFIG, ...localConfig };
+    try {
+      const localConfig: KarafriendsConfig = parse(
+        fs.readFileSync(configFilepath, { encoding: "utf8", flag: "r" }),
+      );
+      config = { ...DEFAULT_CONFIG, ...localConfig };
+    } catch (err) {
+      // config.yaml is hand-edited by the user (for DAM/Joysound credentials),
+      // so a YAML typo must not crash the app on startup. Fall back to defaults
+      // for this session and, crucially, return before the write-back below so
+      // the user's (fixable) config -- and their credentials -- are preserved.
+      console.error(
+        `Failed to parse ${configFilepath}; using defaults for this session. ` +
+          "Fix the YAML and relaunch to restore your settings:",
+        err,
+      );
+      return applyEnvironmentOverrides({ ...DEFAULT_CONFIG });
+    }
   } else {
     console.log("No local configs found. Using default.");
   }
 
-  // write back defaults
-  fs.mkdirSync(path.dirname(configFilepath), { recursive: true });
-  fs.writeFileSync(configFilepath, stringify(config));
+  // write back defaults (persists any newly-added config fields); best-effort
+  // so an unwritable userData directory doesn't crash startup.
+  try {
+    fs.mkdirSync(path.dirname(configFilepath), { recursive: true });
+    fs.writeFileSync(configFilepath, stringify(config));
+  } catch (err) {
+    console.error(`Failed to write config to ${configFilepath}:`, err);
+  }
 
   return applyEnvironmentOverrides(config);
 }

--- a/src/common/videoDownloader.ts
+++ b/src/common/videoDownloader.ts
@@ -1,6 +1,7 @@
-import { spawn } from "child_process";
+import { ChildProcess, spawn } from "child_process";
 import { app } from "electron"; // tslint:disable-line:no-implicit-dependencies
 import fs from "fs";
+import path from "path";
 import process from "process";
 
 import invariant from "ts-invariant";
@@ -29,14 +30,69 @@ interface JoysoundVideoData {
 
 const resourcePaths = getResourcePaths();
 
-function deleteTempFiles(prefix: string): void {
-  for (const filename of fs.readdirSync(TEMP_FOLDER)) {
-    if (!filename) {
-      continue;
-    }
+// Filesystem cleanup helpers. These run inside async spawn/exit callbacks where
+// an uncaught throw would crash the whole app, so they must never throw: a
+// missing or already-removed file during cleanup is not fatal.
+function safeUnlink(filename: string): void {
+  try {
+    fs.rmSync(filename, { force: true });
+  } catch (err) {
+    console.error(`Failed to remove ${filename}:`, err);
+  }
+}
 
-    if (filename.includes(prefix)) {
-      fs.unlinkSync(filename);
+function safeRename(from: string, to: string): void {
+  try {
+    fs.renameSync(from, to);
+  } catch (err) {
+    console.error(`Failed to rename ${from} -> ${to}:`, err);
+  }
+}
+
+// A spawned binary (ffmpeg / yt-dlp) emits an "error" event if it can't be
+// launched (missing, not executable, etc). Unhandled, an EventEmitter "error"
+// throws and crashes the app -- a real risk now that these binaries are
+// downloaded at runtime. Log it and run the caller's cleanup instead of letting
+// one failed download take everything down.
+function handleProcessError(
+  proc: ChildProcess,
+  label: string,
+  cleanup: () => void,
+): void {
+  proc.on("error", (err) => {
+    console.error(`${label} failed to run:`, err);
+    try {
+      cleanup();
+    } catch (cleanupErr) {
+      console.error(`${label} cleanup failed:`, cleanupErr);
+    }
+  });
+}
+
+// A log write stream can emit "error" (bad path, disk full); unhandled, it
+// crashes the app. Logging is best-effort, so swallow it.
+function attachLogStreamErrorHandler(
+  stream: fs.WriteStream,
+  label: string,
+): void {
+  stream.on("error", (err) => {
+    console.error(`${label} log stream error:`, err);
+  });
+}
+
+function deleteTempFiles(prefix: string): void {
+  let filenames: string[];
+  try {
+    filenames = fs.readdirSync(TEMP_FOLDER);
+  } catch (err) {
+    console.error(`Failed to list ${TEMP_FOLDER} for cleanup:`, err);
+    return;
+  }
+  for (const filename of filenames) {
+    if (filename && filename.includes(prefix)) {
+      // NB: readdirSync returns bare names; they must be joined with
+      // TEMP_FOLDER or the unlink targets the wrong (cwd-relative) path.
+      safeUnlink(path.join(TEMP_FOLDER, filename));
     }
   }
 }
@@ -196,6 +252,7 @@ function downloadDamVideoImpl(
 
   const ffmpegLogFilename = `${TEMP_FOLDER}/dam-${songId}.log`;
   const ffmpegLogStream = fs.createWriteStream(ffmpegLogFilename);
+  attachLogStreamErrorHandler(ffmpegLogStream, "ffmpeg (DAM)");
 
   const ffmpeg = spawn(
     resourcePaths.ffmpeg,
@@ -221,9 +278,11 @@ function downloadDamVideoImpl(
   ffmpeg.stderr.pipe(process.stderr);
   ffmpeg.stderr.pipe(ffmpegLogStream);
 
+  handleProcessError(ffmpeg, "ffmpeg (DAM)", () => safeUnlink(tempFilename));
+
   ffmpeg.on("exit", (code, signal) => {
     if (code === 0) {
-      fs.renameSync(tempFilename, filename);
+      safeRename(tempFilename, filename);
     } else {
       console.error(
         `Error downloading DAM video with ID ${songId}: code=${code}, signal=${signal}, log=${ffmpegLogFilename}`,
@@ -243,6 +302,7 @@ function makeJoysoundFFmpegCall(
   const ffmpegLogStream = fs.createWriteStream(ffmpegLogFilename, {
     flags: "a",
   });
+  attachLogStreamErrorHandler(ffmpegLogStream, "ffmpeg (Joysound)");
 
   const ffmpeg = spawn(resourcePaths.ffmpeg, ffmpegArgs, {
     stdio: ["pipe", "pipe", "pipe"],
@@ -264,6 +324,14 @@ function makeJoysoundFFmpegCall(
   if (onExit) {
     ffmpeg.on("exit", onExit);
   }
+
+  // If ffmpeg can't be launched at all, drive the same exit path (non-zero
+  // code) so the wrapping promise rejects instead of hanging or crashing.
+  handleProcessError(ffmpeg, "ffmpeg (Joysound)", () => {
+    if (onExit) {
+      onExit(-1, 0);
+    }
+  });
 
   if (stdinBuffer) {
     ffmpeg.stdin.write(stdinBuffer);
@@ -350,6 +418,7 @@ function downloadJoysoundYoutubeVideoPromise(
   return new Promise((resolve, reject) => {
     const ytdlpLogFilename = `${TEMP_FOLDER}/yt-${youtubeVideoId}.log`;
     const ytdlpLogStream = fs.createWriteStream(ytdlpLogFilename);
+    attachLogStreamErrorHandler(ytdlpLogStream, "yt-dlp");
 
     const env = { ...process.env };
     // Don't need a proxy to download from YouTube
@@ -391,10 +460,15 @@ function downloadJoysoundYoutubeVideoPromise(
       handleYoutubeDownloadLog(data.toString(), downloadQueueItem);
     });
 
+    handleProcessError(ytdlp, "yt-dlp (Joysound/YouTube)", () => {
+      removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
+      reject(-1);
+    });
+
     ytdlp.on("exit", (code, signal) => {
       if (code === 0) {
-        fs.unlinkSync(tempFilename);
-        fs.renameSync(tempFilename + ".mp4", tempFilename);
+        safeUnlink(tempFilename);
+        safeRename(tempFilename + ".mp4", tempFilename);
 
         removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
 
@@ -455,7 +529,7 @@ function composeJoysoundVideoPromise(
     };
 
     const onExit = (code: number, signal: number) => {
-      fs.unlinkSync(tempFilename);
+      safeUnlink(tempFilename);
 
       if (code === 0) {
         const metadata: JoysoundVideoData = {
@@ -680,14 +754,14 @@ function padJoysoundVideoPromise(
 
         const onExit = (code: number, signal: number) => {
           if (code === 0) {
-            fs.renameSync(videoFilename, videoTempFilename);
-            fs.renameSync(videoOutFilename, videoFilename);
+            safeRename(videoFilename, videoTempFilename);
+            safeRename(videoOutFilename, videoFilename);
 
-            fs.unlinkSync(videoNoSoundFilename);
-            fs.unlinkSync(videoPadFrameFilename);
-            fs.unlinkSync(videoPadFilename);
-            fs.unlinkSync(videoTempFilename);
-            fs.unlinkSync(videoConcatFilename);
+            safeUnlink(videoNoSoundFilename);
+            safeUnlink(videoPadFrameFilename);
+            safeUnlink(videoPadFilename);
+            safeUnlink(videoTempFilename);
+            safeUnlink(videoConcatFilename);
 
             pushSongToQueue(queueItem, pushToHead);
 
@@ -788,7 +862,7 @@ function downloadJoysoundDataImpl(
         `${videoFilename} already exists, but ${telopFilename} does not.`,
       );
 
-      fs.unlinkSync(videoFilename);
+      safeUnlink(videoFilename);
     }
   }
 
@@ -901,6 +975,15 @@ function downloadJoysoundDataImpl(
       } else {
         pushSongToQueue(queueItem, pushToHead);
       }
+    })
+    .catch((err) => {
+      // This chain is fire-and-forget (not awaited by the caller), so an
+      // unhandled rejection here — a Joysound API failure, an ffmpeg/yt-dlp
+      // launch failure, bad telop/ogg data, etc. — would otherwise reach the
+      // process-level handler and crash the app. Fail just this download.
+      console.error(`Error downloading Joysound video with ID ${songId}:`, err);
+      removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
+      deleteTempFiles(filenamePrefix);
     });
 }
 
@@ -979,6 +1062,8 @@ function downloadYoutubeVideoImpl(
 
   const ytdlpLogStream = fs.createWriteStream(ytdlpLogFilename);
 
+  attachLogStreamErrorHandler(ytdlpLogStream, "yt-dlp");
+
   const captionArgs = captionCode
     ? ["--write-subs", "--sub-langs", captionCode]
     : [];
@@ -1015,10 +1100,15 @@ function downloadYoutubeVideoImpl(
     handleYoutubeDownloadLog(data.toString(), downloadQueueItem);
   });
 
+  handleProcessError(ytdlp, "yt-dlp", () => {
+    removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
+    safeUnlink(tempFilename);
+  });
+
   ytdlp.on("exit", (code, signal) => {
     removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
 
-    fs.unlinkSync(tempFilename);
+    safeUnlink(tempFilename);
 
     if (code !== 0) {
       console.error(
@@ -1100,6 +1190,8 @@ function downloadNicoVideoImpl(
 
   const ytdlpLogStream = fs.createWriteStream(ytdlpLogFilename);
 
+  attachLogStreamErrorHandler(ytdlpLogStream, "yt-dlp");
+
   const env = { ...process.env };
   // Don't need a proxy to download from Niconico
   delete process.env.http_proxy;
@@ -1132,10 +1224,15 @@ function downloadNicoVideoImpl(
     handleYoutubeDownloadLog(data.toString(), downloadQueueItem);
   });
 
+  handleProcessError(ytdlp, "yt-dlp", () => {
+    removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
+    safeUnlink(tempFilename);
+  });
+
   ytdlp.on("exit", (code, signal) => {
     removeVideoDownloadFromQueue(downloadQueue, downloadQueueItem);
 
-    fs.unlinkSync(tempFilename);
+    safeUnlink(tempFilename);
 
     if (code === 0) {
       onComplete();

--- a/src/main/graphql.ts
+++ b/src/main/graphql.ts
@@ -17,6 +17,8 @@ import { type FetcherRequestInit } from "@apollo/utils.fetcher";
 // tslint:disable-next-line:no-submodule-imports
 import { expressMiddleware } from "@as-integrations/express5";
 import { makeExecutableSchema } from "@graphql-tools/schema";
+// tslint:disable-next-line:no-implicit-dependencies
+import { app as electronApp, dialog } from "electron";
 import isDev from "electron-is-dev";
 import express, { Application } from "express";
 import { PubSub } from "graphql-subscriptions";
@@ -185,10 +187,7 @@ interface NicoQueueItem extends QueueItemInterface {
 }
 
 type QueueItem =
-  | DamQueueItem
-  | JoysoundQueueItem
-  | YoutubeQueueItem
-  | NicoQueueItem;
+  DamQueueItem | JoysoundQueueItem | YoutubeQueueItem | NicoQueueItem;
 
 type QueueSongInfo = {
   readonly __typename: "QueueSongInfo";
@@ -321,25 +320,32 @@ const DB_PATH = path.resolve(TEMP_FOLDER, "queue.json");
 
 // TODO: write a db interface and call these from within mutating methods instead of at their call sites
 function saveDb() {
-  if (!fs.existsSync(TEMP_FOLDER)) {
-    fs.mkdirSync(TEMP_FOLDER);
-  }
-  fs.writeFileSync(
-    DB_PATH,
-    JSON.stringify({
+  try {
+    if (!fs.existsSync(TEMP_FOLDER)) {
+      fs.mkdirSync(TEMP_FOLDER, { recursive: true });
+    }
+    const serialized = JSON.stringify({
       ...db,
       pitchShiftSemis: 0,
       currentSong: null,
       currentSongAdhocLyrics: [],
       songQueue: [db.currentSong, ...db.songQueue],
       downloadQueue: [],
-    }),
-    "utf-8",
-  );
+    });
+    // Write to a temp file and rename into place so an interrupted write can
+    // never leave a half-written queue.json that fails to parse on next launch.
+    const tmpPath = `${DB_PATH}.tmp`;
+    fs.writeFileSync(tmpPath, serialized, "utf-8");
+    fs.renameSync(tmpPath, DB_PATH);
+  } catch (err) {
+    // A failed persist shouldn't take down the app; the in-memory queue is
+    // still intact and will be retried on the next mutation.
+    console.error(`Failed to persist queue to ${DB_PATH}:`, err);
+  }
 }
 
 function loadDb(): NotARealDb {
-  return {
+  const defaults: NotARealDb = {
     currentSong: null,
     currentSongAdhocLyrics: [],
     idToAdhocLyrics: {},
@@ -348,9 +354,27 @@ function loadDb(): NotARealDb {
     songQueue: [],
     downloadQueue: [],
     songHistory: [],
-    ...(fs.existsSync(DB_PATH) &&
-      JSON.parse(fs.readFileSync(DB_PATH, "utf-8"))),
   };
+  if (!fs.existsSync(DB_PATH)) {
+    return defaults;
+  }
+  try {
+    return { ...defaults, ...JSON.parse(fs.readFileSync(DB_PATH, "utf-8")) };
+  } catch (err) {
+    // A corrupt or partially-written queue.json (e.g. an interrupted save or a
+    // power loss mid-party) previously threw here at startup, bricking every
+    // launch. Preserve the bad file for debugging and start from a clean state.
+    console.error(
+      `Failed to load saved queue from ${DB_PATH}; ignoring it:`,
+      err,
+    );
+    try {
+      fs.renameSync(DB_PATH, `${DB_PATH}.corrupt`);
+    } catch (renameErr) {
+      console.error("Failed to back up corrupt queue file:", renameErr);
+    }
+    return defaults;
+  }
 }
 
 const pubsub = new PubSub();
@@ -1216,6 +1240,26 @@ export function applyGraphQLMiddleware(app: Application) {
     path: "/graphql",
   });
 
+  // These servers are EventEmitters: an unhandled "error" event (most commonly
+  // the remocon port already being in use) would otherwise crash the whole app
+  // with a bare stack trace. Fail loudly with a clear message and quit cleanly.
+  httpServer.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      dialog.showErrorBox(
+        "karafriends: port already in use",
+        `Port ${karafriendsConfig.remoconPort} is already in use. ` +
+          "Is karafriends already running? Close the other instance " +
+          "(or free the port) and relaunch.",
+      );
+    } else {
+      console.error("HTTP server error:", err);
+    }
+    electronApp.quit();
+  });
+  wsServer.on("error", (err) => {
+    console.error("WebSocket server error:", err);
+  });
+
   const serverCleanup = useServer({ schema }, wsServer);
 
   db = loadDb();
@@ -1258,38 +1302,47 @@ export function applyGraphQLMiddleware(app: Application) {
     return nodeFetch(url, { ...init, agent: tunnelAgent });
   };
 
-  server.start().then(() => {
-    app.use(
-      "/graphql",
-      express.json(),
-      expressMiddleware(server, {
-        context: async () => {
-          const innertubeApiInstance = await innertubeApiProvider();
+  server
+    .start()
+    .then(() => {
+      app.use(
+        "/graphql",
+        express.json(),
+        expressMiddleware(server, {
+          context: async () => {
+            const innertubeApiInstance = await innertubeApiProvider();
 
-          return {
-            dataSources: {
-              minsei: new MinseiAPI(minseiCredentialsProvider, {
-                cache: server.cache,
-                fetch: fetcher,
-              }),
-              joysound: new JoysoundAPI(joysoundCredentialsProvider, {
-                cache: server.cache,
-                fetch: fetcher,
-              }),
-              dkwebsys: new DkwebsysAPI({
-                cache: server.cache,
-                fetch: fetcher,
-              }),
-              youtube: innertubeApiInstance,
-            },
-          };
-        },
-      }),
-    );
-    httpServer.listen(karafriendsConfig.remoconPort, () => {
-      console.log(
-        `Server is now running on http://localhost:${karafriendsConfig.remoconPort}`,
+            return {
+              dataSources: {
+                minsei: new MinseiAPI(minseiCredentialsProvider, {
+                  cache: server.cache,
+                  fetch: fetcher,
+                }),
+                joysound: new JoysoundAPI(joysoundCredentialsProvider, {
+                  cache: server.cache,
+                  fetch: fetcher,
+                }),
+                dkwebsys: new DkwebsysAPI({
+                  cache: server.cache,
+                  fetch: fetcher,
+                }),
+                youtube: innertubeApiInstance,
+              },
+            };
+          },
+        }),
       );
+      httpServer.listen(karafriendsConfig.remoconPort, () => {
+        console.log(
+          `Server is now running on http://localhost:${karafriendsConfig.remoconPort}`,
+        );
+      });
+    })
+    .catch((err) => {
+      // server.start() rejecting leaves the app with no GraphQL backend, so there
+      // is nothing useful to keep running — surface it and quit cleanly.
+      console.error("Failed to start the GraphQL server:", err);
+      dialog.showErrorBox("karafriends: failed to start", String(err));
+      electronApp.quit();
     });
-  });
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -205,7 +205,7 @@ app.on("login", (event, webContents, request, authInfo, callback) => {
   );
   if (karafriendsConfig.proxyEnable) {
     const { proxyHost, proxyPort, proxyUser, proxyPass } = karafriendsConfig;
-    console.log(`Time to login to ${proxyURL}:${proxyPort}`);
+    console.log(`Time to login to ${proxyHost}:${proxyPort}`);
     callback(proxyUser, proxyPass);
     event.preventDefault();
   } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,6 +90,15 @@ function createWindow() {
     },
   });
 
+  // A renderer crash (GPU reset, OOM, native fault) would otherwise leave the
+  // karaoke display permanently blank. Reload the window so the show goes on.
+  rendererWindow.webContents.on("render-process-gone", (_event, details) => {
+    console.error(`Renderer process gone (${details.reason})`);
+    if (details.reason !== "clean-exit") {
+      rendererWindow?.reload();
+    }
+  });
+
   // Ignore CORS when fetching ipcasting HLS and when sending requests to remocon
   const session = rendererWindow.webContents.session;
   const ignoreCORSFilter = {
@@ -112,18 +121,21 @@ function createWindow() {
     (details, callback) => {
       // Chrome is not happy if ACAO is set twice, which is what happens
       // when the Express static middleware is setting this one
-      delete details.responseHeaders!["access-control-allow-origin"];
-      details.responseHeaders!["Access-Control-Allow-Origin"] = ["*"];
+      if (details.responseHeaders) {
+        delete details.responseHeaders["access-control-allow-origin"];
+        details.responseHeaders["Access-Control-Allow-Origin"] = ["*"];
+      }
       callback({ responseHeaders: details.responseHeaders });
     },
   );
 
   if (karafriendsConfig.proxyEnable) {
-    session.setProxy({
-      proxyRules: `${karafriendsConfig.proxyHost}:${karafriendsConfig.proxyPort}`,
-      proxyBypassRules: "<local>,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8",
-    });
-    // Technically should await this promise
+    session
+      .setProxy({
+        proxyRules: `${karafriendsConfig.proxyHost}:${karafriendsConfig.proxyPort}`,
+        proxyBypassRules: "<local>,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8",
+      })
+      .catch((err) => console.error("Failed to set proxy:", err));
   }
 
   protocol.registerFileProtocol("karafriends", (request, callback) => {

--- a/src/main/mdns.ts
+++ b/src/main/mdns.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 import mdns from "multicast-dns";
 
 import { HOSTNAME } from "../common/constants";
@@ -5,20 +6,32 @@ import ipAddresses from "../common/ipAddresses";
 
 export default function setupMdns() {
   const mdnsObj = mdns();
+  // The mDNS socket is an EventEmitter; an unhandled "error" event (e.g. a
+  // transient network/socket error) would throw and take down the whole app.
+  // mDNS is best-effort discovery, so log and keep running instead. (The
+  // multicast-dns typings only declare the "query" event, hence the cast.)
+  (mdnsObj as unknown as EventEmitter).on("error", (err: unknown) => {
+    console.error("mDNS error:", err);
+  });
   mdnsObj.on("query", (query: any) => {
-    if (
-      query.questions[0] &&
-      query.questions[0].name === HOSTNAME &&
-      query.questions[0].type === "A"
-    ) {
-      mdnsObj.respond({
-        answers: ipAddresses().map((address) => ({
-          name: HOSTNAME,
-          type: "A",
-          ttl: 300,
-          data: address,
-        })),
-      });
+    try {
+      if (
+        query.questions[0] &&
+        query.questions[0].name === HOSTNAME &&
+        query.questions[0].type === "A"
+      ) {
+        mdnsObj.respond({
+          answers: ipAddresses().map((address) => ({
+            name: HOSTNAME,
+            type: "A",
+            ttl: 300,
+            data: address,
+          })),
+        });
+      }
+    } catch (err) {
+      // Runs in an event-emitter callback, so a throw here is uncaught.
+      console.error("Failed to respond to mDNS query:", err);
     }
   });
 }

--- a/src/renderer/ErrorBoundary.tsx
+++ b/src/renderer/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import * as Sentry from "@sentry/browser";
+import React from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+// A render error anywhere in the tree would otherwise unmount the whole
+// karaoke display and leave a blank screen with no way to recover. Catch it,
+// report it, and show a minimal recovery UI instead so a host can get the
+// display back without restarting the app.
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("Renderer error boundary caught an error:", error, info);
+    Sentry.captureException(error);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100vh",
+            gap: "1rem",
+            fontFamily: "sans-serif",
+            textAlign: "center",
+            padding: "2rem",
+          }}
+        >
+          <h1>Something went wrong</h1>
+          <p>The karaoke display hit an unexpected error.</p>
+          <button
+            style={{ fontSize: "1.25rem", padding: "0.5rem 1.5rem" }}
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -9,6 +9,7 @@ import { RelayEnvironmentProvider } from "react-relay";
 import environment from "../common/graphqlEnvironment";
 import { KuroshiroSingleton } from "../common/joysoundParser";
 import App from "./App";
+import ErrorBoundary from "./ErrorBoundary";
 import "./index.css";
 import KarafriendsAudio from "./webAudio";
 
@@ -34,8 +35,10 @@ const root = createRoot(container!);
 
 root.render(
   <React.StrictMode>
-    <RelayEnvironmentProvider environment={environment}>
-      <App kuroshiro={kuroshiroSingleton} audio={audio} />
-    </RelayEnvironmentProvider>
-  </React.StrictMode>
+    <ErrorBoundary>
+      <RelayEnvironmentProvider environment={environment}>
+        <App kuroshiro={kuroshiroSingleton} audio={audio} />
+      </RelayEnvironmentProvider>
+    </ErrorBoundary>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
The main process installs `uncaughtException`/`unhandledRejection` handlers that call `process.exit(1)`, so **any** uncaught throw or unhandled rejection outside the Apollo resolver chain kills a live karaoke session. This PR handles the **known, localized, recoverable** failures at their source. Truly-unexpected errors still fail loudly via the existing handlers — this intentionally does *not* touch the global handlers.

### videoDownloader (the biggest surface)
- Every ffmpeg/yt-dlp `spawn()` now has an `"error"` listener. An unlaunchable binary — a real risk now that they're downloaded at runtime — otherwise emits an unhandled EventEmitter `"error"` that throws and crashes the app. On error we log, clean up the temp file, drop the download from the queue (or reject its promise).
- Log write streams get `"error"` listeners (a bad path / full disk otherwise crashes).
- Temp-file `unlink`/`rename` inside async exit callbacks are guarded (`safeUnlink`/`safeRename`) so an already-removed file can't throw.
- The fire-and-forget Joysound download promise chain (`Promise.all(...).then().then()`) gets a `.catch`.
- **Bug fix:** `deleteTempFiles` joined bare `readdir` names with `TEMP_FOLDER` (it was unlinking cwd-relative paths and throwing) and guards the `readdir`.

### graphql
- `loadDb` no longer throws on a corrupt/partial `queue.json` — it backs the file up (`.corrupt`) and starts clean instead of **bricking every launch**.
- `saveDb` writes atomically (temp file + rename) so an interrupted write can't produce that corrupt file in the first place.
- `httpServer`/`wsServer` get `"error"` handlers — **EADDRINUSE** (port taken / double-launch) shows a clear dialog and quits cleanly instead of a bare crash — and `server.start()` gets a `.catch`.

### mdns
- Added an `"error"` handler on the mDNS socket and wrapped the query handler.

### index
- Fixed a `ReferenceError` (`proxyURL` → `proxyHost`) that crashed the proxy `login` handler. (Caught by `tsc`, which isn't in CI — see the follow-up tooling PR.)

Verified: `yarn build-dev` + `yarn test:unit` pass; no new `tsc` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)