### PR TITLE
Fix queue polling stopping when the queue empties

### DIFF
--- a/src/renderer/Player.tsx
+++ b/src/renderer/Player.tsx
@@ -99,16 +99,19 @@ function Player(props: {
         mutation: popSongMutation,
         variables: {},
         onCompleted: ({ popSong }) => {
-          if (!popSong) return;
           if (!videoRef.current) return;
-          if (trackRef?.current) {
-            trackRef.current.default = false;
-            trackRef.current.src = "";
-          }
 
-          setPitchShiftSemis(0);
+          if (popSong) {
+            // Only reset caption/pitch state when we actually have a song to
+            // play; doing it on every empty poll would spam the pitch-shift
+            // mutation while idle.
+            if (trackRef?.current) {
+              trackRef.current.default = false;
+              trackRef.current.src = "";
+            }
 
-          if (popSong !== null) {
+            setPitchShiftSemis(0);
+
             if (hls) hls.destroy();
 
             switch (popSong.__typename) {


### PR DESCRIPTION
## Bug
In `Player.tsx`, `pollQueue`'s `onCompleted` starts with:
```ts
if (!popSong) return;
```
When the queue is empty, `popSong` is `null`, so this returns **before** the `else` branch that re-arms the poll timer:
```ts
} else {
  setPlaybackState("WAITING");
  pollTimeoutRef.current = setTimeout(pollQueue, POLL_INTERVAL_MS); // never reached
}
```
So the reschedule-when-empty path was dead code: once the queue drained, polling stopped permanently and a newly-queued song never auto-played until the app was restarted.

## Fix
Remove the early return and gate the song-setup work on `if (popSong)` (truthy — same as the original null/undefined check), so the `else` re-arms the poll while the queue is empty. The caption/pitch reset moved inside the truthy branch so it doesn't run (and spam the pitch-shift mutation) on every empty poll.

Verified: `tsc` clean for `Player.tsx`, `yarn build-dev` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)