### PR TITLE
Prevent hangs and blank displays: timeouts, load retry, innertube

### DIFF
--- a/src/common/externalResources.ts
+++ b/src/common/externalResources.ts
@@ -83,25 +83,57 @@ async function fetchAsset(
     if (attempt > 0) {
       await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
     }
+    // Time out the request itself so a connection that hangs (rather than
+    // erroring) doesn't stall forever. ensureExternalResources() is
+    // single-flight, so one hung fetch would otherwise wedge every download.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30000);
     try {
-      const res = await fetch(url, { headers });
+      const res = await fetch(url, { headers, signal: controller.signal });
       if (res.ok || res.status === 304) {
         return res;
       }
       lastError = new Error(String(res.status));
     } catch (error) {
       lastError = error;
+    } finally {
+      // Headers have arrived (or we failed); stop the timer so it can't abort
+      // an in-progress body stream we're about to hand back for downloading.
+      clearTimeout(timer);
     }
   }
   throw lastError;
 }
 
+const DOWNLOAD_STALL_MS = 60000;
+
 async function streamToFile(res: FetchResponse, dest: string): Promise<void> {
   const fileStream = fs.createWriteStream(dest);
+  const body = res.body!;
   await new Promise<void>((resolve, reject) => {
-    res.body!.pipe(fileStream);
-    res.body!.on("error", reject);
-    fileStream.on("finish", () => resolve());
+    // Watchdog: if the body produces no data for DOWNLOAD_STALL_MS, treat it as
+    // a stalled download and fail so the caller can retry instead of hanging.
+    let stallTimer: ReturnType<typeof setTimeout>;
+    const armStall = () => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(
+        () =>
+          (body as unknown as import("stream").Readable).destroy(
+            new Error(`download stalled: ${dest}`),
+          ),
+        DOWNLOAD_STALL_MS,
+      );
+    };
+    const settle = (fn: () => void) => {
+      clearTimeout(stallTimer);
+      fn();
+    };
+    armStall();
+    body.on("data", armStall);
+    body.pipe(fileStream);
+    body.on("error", (err) => settle(() => reject(err)));
+    fileStream.on("error", (err) => settle(() => reject(err)));
+    fileStream.on("finish", () => settle(() => resolve()));
   });
 }
 

--- a/src/main/graphql.ts
+++ b/src/main/graphql.ts
@@ -1226,9 +1226,42 @@ export const joysoundCredentialsProvider = memoize(async () => {
   return JoysoundAPI.login(joysoundEmail, joysoundPassword);
 });
 
-const innertubeApiProvider = memoize(async () => {
-  return Innertube.create();
-});
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() =>
+    clearTimeout(timer),
+  ) as Promise<T>;
+}
+
+// Every GraphQL request awaits this to build its context, so if
+// Innertube.create() hangs (YouTube unreachable) it would stall the entire
+// API. memoize would also cache a rejected promise forever, permanently
+// killing the backend until restart. Use a manual singleton that times out and
+// clears itself on failure so the next request retries.
+let innertubePromise: Promise<Innertube> | null = null;
+function innertubeApiProvider(): Promise<Innertube> {
+  if (!innertubePromise) {
+    innertubePromise = withTimeout(
+      Innertube.create(),
+      30000,
+      "Innertube.create",
+    ).catch((err) => {
+      innertubePromise = null;
+      throw err;
+    });
+  }
+  return innertubePromise;
+}
 
 export function applyGraphQLMiddleware(app: Application) {
   const httpServer = createServer(app);
@@ -1297,7 +1330,20 @@ export function applyGraphQLMiddleware(app: Application) {
     : undefined;
 
   const fetcher = async (url: string, init?: FetcherRequestInit) => {
-    return nodeFetch(url, { ...init, agent: tunnelAgent });
+    // Without a timeout, a hung upstream (DAM/Joysound) stalls the resolver —
+    // and the client request — indefinitely. Abort after 30s so it surfaces as
+    // an error (and the promise-retry wrappers can retry) instead of hanging.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30000);
+    try {
+      return await nodeFetch(url, {
+        ...init,
+        agent: tunnelAgent,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
   };
 
   server

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -155,12 +155,37 @@ function createWindow() {
   // This middleware terminates the request/response cycle and should be applied last
   expressApp.use(remoconReverseProxy(karafriendsConfig.devPort));
 
-  if (rendererWindow)
-    rendererWindow.loadURL(
-      isDev
-        ? `http://localhost:${karafriendsConfig.devPort}/renderer/`
-        : `file://${path.join(__dirname, "..", "..", "build", "prod", "renderer", "index.html")}`,
+  if (rendererWindow) {
+    const rendererUrl = isDev
+      ? `http://localhost:${karafriendsConfig.devPort}/renderer/`
+      : `file://${path.join(__dirname, "..", "..", "build", "prod", "renderer", "index.html")}`;
+    // A failed load (dev server not ready, a transient file/protocol error)
+    // would leave the karaoke display blank, and the unhandled loadURL
+    // rejection would reach the process-level handler. Catch it and retry a few
+    // times so the show still comes up.
+    let rendererLoadAttempts = 0;
+    const loadRenderer = () => {
+      rendererWindow
+        ?.loadURL(rendererUrl)
+        .catch((err) =>
+          console.error(`Failed to load renderer ${rendererUrl}:`, err),
+        );
+    };
+    rendererWindow.webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, _url, isMainFrame) => {
+        // -3 (ERR_ABORTED) is a benign navigation cancel, not a real failure.
+        if (!isMainFrame || errorCode === -3) return;
+        console.error(
+          `Renderer failed to load (${errorCode} ${errorDescription})`,
+        );
+        if (rendererLoadAttempts++ < 10) {
+          setTimeout(loadRenderer, 1000);
+        }
+      },
     );
+    loadRenderer();
+  }
 
   ipcMain.on("config", (event: IpcMainEvent) => {
     console.log("Sending config over ipc");


### PR DESCRIPTION
Third reliability pass, focused on things that **stall** rather than throw.

### No fetch had a timeout → a hung (vs. erroring) connection stalled forever
- **DAM/Joysound `fetcher`**: aborts after 30s, so a stuck upstream surfaces as an error the existing `promiseRetry` wrappers retry instead of hanging the resolver (and the client request).
- **Runtime resource downloader**: 30s request timeout + a 60s idle-stall watchdog on the body stream. This matters doubly because `ensureExternalResources()` is single-flight — one hung fetch would otherwise wedge *every* video download with no recovery.

### `innertubeApiProvider`
Awaited by **every** GraphQL request to build its context. A hung `Innertube.create()` stalled the whole API, and `memoize` would cache a *rejected* promise forever (backend permanently dead until restart). Replaced with a manual singleton that times out (30s) and **clears itself on failure** so the next request retries.

### `rendererWindow.loadURL`
No error handling → a failed load left the karaoke display blank *and* produced an unhandled rejection. Added a `did-fail-load` retry (up to 10×, ignoring benign `ERR_ABORTED`) plus a `.catch`.

Verified: `yarn typecheck` (0 errors), `yarn build-dev`, `yarn test:unit` all pass.

Noted but not included (low value): the `minsei`/`joysound` creds providers share the same `memoize`-caches-rejection pattern (only affects DAM/Joysound auth, ~one-time), and `remoconReverseProxy`'s missing `.catch` is dev-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)