### PR TITLE
Dependabot: 7-day version cooldown + auto-merge on green CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,25 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1000
+    # Only propose versions that have been published for at least a week, so we
+    # skip releases that get yanked or hotfixed shortly after publishing.
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1000
+    # Only propose versions that have been published for at least a week, so we
+    # skip releases that get yanked or hotfixed shortly after publishing.
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1000
+    # Only propose versions that have been published for at least a week, so we
+    # skip releases that get yanked or hotfixed shortly after publishing.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,56 @@
+name: Dependabot auto-merge
+
+# Auto-merge a Dependabot PR once the Build workflow has succeeded for it.
+#
+# This runs via workflow_run rather than on: pull_request for two reasons:
+#   1. It only fires after Build completes, and we gate on conclusion ==
+#      "success", so a PR is merged only if it actually passed CI.
+#   2. workflow_run executes in the base-repo context with a token that honors
+#      the permissions below. Dependabot's own pull_request token is read-only,
+#      so it could not merge from a pull_request-triggered workflow.
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    # Only for successful Build runs that came from a Dependabot pull request.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    steps:
+      - name: Merge the Dependabot PR that passed CI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Resolve the PR from the commit that Build ran against.
+          pr=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            --jq '.[] | select(.state == "open") | .number' | head -n1)
+          if [ -z "$pr" ]; then
+            echo "No open PR found for $HEAD_SHA; nothing to merge."
+            exit 0
+          fi
+
+          # Defense in depth: confirm the PR is actually authored by Dependabot
+          # before merging.
+          author=$(gh pr view "$pr" --repo "$REPO" --json author --jq '.author.login')
+          case "$author" in
+            "app/dependabot" | "dependabot[bot]") ;;
+            *)
+              echo "PR #$pr is authored by '$author', not Dependabot; skipping."
+              exit 0
+              ;;
+          esac
+
+          echo "Build passed for Dependabot PR #$pr; squash-merging."
+          gh pr merge "$pr" --repo "$REPO" --squash --delete-branch


### PR DESCRIPTION
Two changes requested: gate Dependabot to versions ≥1 week old, and auto-merge Dependabot PRs that pass CI.

### 1. 7-day cooldown (`.github/dependabot.yml`)
Adds `cooldown: { default-days: 7 }` to each ecosystem (cargo `/native`, npm `/`, github-actions). Dependabot will only open a PR once the target version has been published for at least 7 days — skipping releases that get yanked or hotfixed right after publishing. Per the docs, cooldown applies to **version** updates only, so **security** updates are unaffected and still land immediately.

### 2. Auto-merge on green CI (`.github/workflows/dependabot-automerge.yml`)
Squash-merges a Dependabot PR once the **Build** workflow succeeds for it.

Implemented with `workflow_run` (triggered on Build `completed`, gated on `conclusion == 'success'`) rather than `on: pull_request`, for two reasons:
- It only merges PRs that **actually passed CI** — without needing branch protection (which, given the self-hosted aarch64 runner's occasional stalls, would otherwise block every human PR too).
- `workflow_run` runs in the base-repo context with a writable token; Dependabot's own `pull_request` token is read-only and couldn't merge.

Scoped to the `dependabot[bot]` actor, with a PR-author double-check before merging, and `contents`/`pull-requests: write` permissions.

Note: this auto-merges **all** green Dependabot PRs. If you'd rather hold major bumps for manual review, that's a small follow-up (add `dependabot/fetch-metadata` and skip `version-update:semver-major`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)