### PR TITLE
Update macOS signing identity for developer name change

### DIFF
--- a/packager.js
+++ b/packager.js
@@ -52,7 +52,7 @@ function bundleExtractor() {
         appleApiIssuer: "69a6de70-1249-47e3-e053-5b8c7c11a4d1",
       },
       osxSign: {
-        identity: "Developer ID Application: Connor Worley (WZ6JC3T383)",
+        identity: "Developer ID Application: Emma Worley (WZ6JC3T383)",
       },
     }),
     ...(process.platform === "win32" && {


### PR DESCRIPTION
The Developer ID Application certificate was reissued under a new name. Inspecting the new cert (`developerID_application (1).cer`):

```
commonName             = Developer ID Application: Emma Worley (WZ6JC3T383)
organizationName       = Emma Worley
organizationalUnitName = WZ6JC3T383   (Team ID — unchanged)
```

So only the name changed (Connor Worley → Emma Worley); the Team ID `WZ6JC3T383` is the same. `packager.js` hardcodes the codesign identity (the cert's common name), so this updates it to match.

**Notarization is unaffected** — `osxNotarize` authenticates with the App Store Connect API key (`appleApiKeyId`/`appleApiIssuer`/`NOTARIZATION_KEY_PATH`), not the certificate name, and the Team ID didn't change.

### ⚠️ Required manual step (can't be done in the repo)
CI signing imports a `.p12` from the **`MACOS_SIGNING_CERT_BASE64`** secret (see `release.yaml` → "Setup code signing cert"). That secret still holds the old cert. It must be re-uploaded as a base64 `.p12` containing the **new certificate _and_ its private key** — the reissued `.cer` alone is just the public certificate and can't sign. To produce it:

```
# In Keychain Access, export the "Developer ID Application: Emma Worley (WZ6JC3T383)"
# identity (cert + key) as a .p12, then:
base64 -i DeveloperIDApplication.p12 | pbcopy   # paste into the MACOS_SIGNING_CERT_BASE64 secret
```
(and set `MACOS_SIGNING_CERT_PASSWORD` to that .p12's export password if it changed.)

Until that secret is updated, a release build would fail at the signing step because the "Emma Worley" identity won't be present in the CI keychain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)