### PR TITLE
Fix native audio buffer-size crash on cpal 0.18

### DIFF
--- a/native/karafriends-lib/src/lib.rs
+++ b/native/karafriends-lib/src/lib.rs
@@ -602,7 +602,16 @@ fn supported_config_to_config(
         buffer_size: match config_range.buffer_size() {
             // WASAPI lies about buffer size ranges and doesn't repect fixed size requests
             #[cfg(not(windows))]
-            cpal::SupportedBufferSize::Range { min, max: _ } => cpal::BufferSize::Fixed(*min),
+            cpal::SupportedBufferSize::Range { min, max } => {
+                // Request a standard 256-frame buffer rather than the reported
+                // minimum. cpal 0.18 validates a fixed buffer size against the
+                // device's real range when the stream is built, and the range
+                // reported here can understate that minimum (e.g. it reports 14
+                // but only 29..=4096 is actually accepted), which made the build
+                // fail. Clamp 256 to the reported range so we stay in bounds;
+                // 256 is what the fixed-config streams elsewhere use too.
+                cpal::BufferSize::Fixed(256u32.clamp(*min, *max))
+            }
             _ => cpal::BufferSize::Default,
         },
     }


### PR DESCRIPTION
## Problem

Native audio failed to start with:

```
Uncaught Error: Buffer size 14 is not in the supported range 29..=4096
```

`supported_config_to_config` requested `BufferSize::Fixed(min)` using the minimum reported by the device's `SupportedBufferSize::Range`. cpal 0.18 validates a fixed buffer size against the device's *real* range when the stream is built, and that reported minimum can understate it — here a device reports `14` but only accepts `29..=4096` — so the stream build failed. This surfaced after the 0.17 → 0.18 migration, which tightened buffer-size validation.

## Fix

Request a standard **256-frame** buffer instead of the unreliable reported minimum (256 is what the fixed-config streams elsewhere in this file already use), clamped to the reported `[min, max]` range so it stays in bounds. 256 sits comfortably inside typical device ranges, keeping `resampler_chunk_size` valid.

## Testing

- `cargo build` / `cargo clippy` — clean
- `cargo test` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)